### PR TITLE
feat: add teams_get_transcript tool for meeting transcripts

### DIFF
--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Review PR
         if: github.event_name == 'pull_request'
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
         run: |
           claude -p --allowedTools "Read,Write" --output-format text "You are a brilliant code reviewer who happens to be a massive fan of Douglas Adams and The Hitchhiker's Guide to the Galaxy. You're the fun one in the office - warm, witty, and genuinely helpful. Your reviews are a pleasure to receive because you balance sharp technical insight with dry humour and an encouraging tone. You never take yourself too seriously, but you take the code seriously.
 
@@ -280,7 +280,7 @@ jobs:
       - name: Respond to comment
         if: github.event_name != 'pull_request' && steps.check-bot.outputs.is_bot != 'true'
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
         run: |
           claude -p --allowedTools "Read,Write" --output-format text "You are a brilliant code reviewer who happens to be a massive fan of Douglas Adams and The Hitchhiker's Guide to the Galaxy. You're the fun one in the office - warm, witty, and genuinely helpful. You're never defensive about your opinions and you're quick to acknowledge when someone makes a good point.
 

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -8,7 +8,7 @@ on:
   pull_request_review_comment:
     types: [created]
 
-# Prevent concurrent reviews on the same PR
+# Prevent concurrent reviews on the same PR (one at a time per PR)
 concurrency:
   group: pr-review-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: false

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -56,14 +56,60 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
-      - name: Get PR diff
+      - name: Get PR context
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh pr diff ${{ github.event.pull_request.number }} > pr-diff.txt
-          echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
           echo "PR_TITLE=${{ github.event.pull_request.title }}" >> $GITHUB_ENV
+          echo "PR_ACTION=${{ github.event.action }}" >> $GITHUB_ENV
+          
+          # Always get the full diff for inline comment validation
+          gh pr diff $PR_NUMBER > pr-diff.txt
+          
+          # Fetch previous bot reviews for conversation context
+          gh api "/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.user.login | contains("[bot]")) | select(.body | contains("pr-reviewer-bot")) | {id: .id, body: .body, submitted_at: .submitted_at}]' > previous-reviews.json 2>/dev/null || echo '[]' > previous-reviews.json
+          
+          REVIEW_COUNT=$(jq 'length' previous-reviews.json)
+          echo "REVIEW_COUNT=$REVIEW_COUNT" >> $GITHUB_ENV
+          
+          if [ "${{ github.event.action }}" = "synchronize" ] && [ "$REVIEW_COUNT" -gt 0 ]; then
+            echo "IS_FOLLOWUP=true" >> $GITHUB_ENV
+            
+            # Get the last review timestamp to find new commits
+            LAST_REVIEW_TIME=$(jq -r 'last | .submitted_at' previous-reviews.json)
+            echo "Last review was at: $LAST_REVIEW_TIME"
+            
+            # Get commits since last review
+            gh api "/repos/${{ github.repository }}/pulls/$PR_NUMBER/commits" \
+              --jq "[.[] | select(.commit.committer.date > \"$LAST_REVIEW_TIME\") | {sha: .sha, message: .commit.message}]" > new-commits.json 2>/dev/null || echo '[]' > new-commits.json
+            
+            NEW_COMMIT_COUNT=$(jq 'length' new-commits.json)
+            echo "New commits since last review: $NEW_COMMIT_COUNT"
+            
+            if [ "$NEW_COMMIT_COUNT" -gt 0 ]; then
+              # Get the parent of the first new commit to diff against
+              FIRST_NEW_SHA=$(jq -r '.[0].sha' new-commits.json)
+              LATEST_SHA=${{ github.event.pull_request.head.sha }}
+              
+              # Generate incremental diff
+              git diff ${FIRST_NEW_SHA}^..${LATEST_SHA} > incremental-diff.txt 2>/dev/null || cp pr-diff.txt incremental-diff.txt
+              
+              # Build commit summary
+              jq -r '.[] | "- " + .sha[:7] + " " + .message' new-commits.json > new-commits-summary.txt
+            else
+              cp pr-diff.txt incremental-diff.txt
+              echo "(no new commits found, using full diff)" > new-commits-summary.txt
+            fi
+            
+            # Extract the last review body for context
+            jq -r 'last | .body' previous-reviews.json > last-review.txt
+          else
+            echo "IS_FOLLOWUP=false" >> $GITHUB_ENV
+          fi
 
       - name: Get PR info for comment
         if: github.event_name != 'pull_request'
@@ -87,9 +133,13 @@ jobs:
           echo "${{ github.event.comment.body }}" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
           echo "COMMENT_USER=${{ github.event.comment.user.login }}" >> $GITHUB_ENV
+          
+          # Fetch previous bot reviews for conversation context
+          gh api "/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.user.login | contains("[bot]")) | select(.body | contains("pr-reviewer-bot")) | {body: .body, submitted_at: .submitted_at}]' > previous-reviews.json 2>/dev/null || echo '[]' > previous-reviews.json
 
-      - name: Review PR
-        if: github.event_name == 'pull_request'
+      - name: Initial PR review
+        if: github.event_name == 'pull_request' && env.IS_FOLLOWUP != 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
         run: |
@@ -124,6 +174,55 @@ jobs:
           - comments array can be empty if no inline feedback needed
           - Be constructive and specific. Focus on meaningful improvements, not style nitpicks.
           - Each comment should explain the issue AND suggest a fix where possible."
+
+      - name: Follow-up PR review
+        if: github.event_name == 'pull_request' && env.IS_FOLLOWUP == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+        run: |
+          claude -p --allowedTools "Read,Write" --output-format text "You are a brilliant code reviewer who happens to be a massive fan of Douglas Adams and The Hitchhiker's Guide to the Galaxy. You're the fun one in the office - warm, witty, and genuinely helpful. You never repeat yourself - you're too interesting for that.
+
+          IMPORTANT: You have already reviewed this PR before. This is a FOLLOW-UP review of new changes only.
+          Do NOT repeat observations from your previous review. Focus exclusively on what's new or changed.
+
+          PR Title: $PR_TITLE
+
+          YOUR PREVIOUS REVIEW:
+          $(cat last-review.txt)
+
+          NEW COMMITS SINCE YOUR LAST REVIEW:
+          $(cat new-commits-summary.txt)
+
+          The incremental diff (new changes only) is in incremental-diff.txt.
+          The full PR diff is in pr-diff.txt if you need broader context.
+
+          Your task:
+          1. Read the incremental diff from incremental-diff.txt
+          2. Check if new commits address any of your previous feedback
+          3. Identify any NEW issues in the new changes only
+          4. Write your review as JSON to review-output.json
+
+          OUTPUT FORMAT (review-output.json):
+          {
+            \"summary\": \"Brief assessment of the new changes. Acknowledge what was fixed from your previous review. Only flag genuinely new issues.\",
+            \"verdict\": \"approve\" | \"request_changes\" | \"comment\",
+            \"comments\": [
+              {
+                \"path\": \"src/example.ts\",
+                \"line\": 42,
+                \"body\": \"Your observation here. For code suggestions use:\\n\\\`\\\`\\\`suggestion\\ncorrected code\\n\\\`\\\`\\\`\"
+              }
+            ]
+          }
+
+          RULES:
+          - This is a conversation, not a fresh review. Be conversational and acknowledge progress.
+          - Do NOT repeat any feedback from your previous review unless it's still unaddressed.
+          - If all your previous concerns were addressed and the new changes look good, just approve with a brief positive note.
+          - 'line' MUST be visible in the full PR diff (pr-diff.txt) - check @@ line numbers carefully.
+          - 'path' must match exactly a file path from the diff.
+          - comments array can be empty if no inline feedback needed.
+          - Keep it brief. Nobody likes a reviewer who repeats themselves."
 
       - name: Post review with inline comments
         if: github.event_name == 'pull_request'
@@ -282,9 +381,19 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
         run: |
+          # Build review history context
+          REVIEW_HISTORY=""
+          if [ -s previous-reviews.json ] && [ "$(jq 'length' previous-reviews.json)" -gt 0 ]; then
+            REVIEW_HISTORY="YOUR PREVIOUS REVIEWS ON THIS PR:
+          $(jq -r '.[] | "--- Review from " + .submitted_at + " ---\n" + .body + "\n"' previous-reviews.json)"
+          fi
+          
           claude -p --allowedTools "Read,Write" --output-format text "You are a brilliant code reviewer who happens to be a massive fan of Douglas Adams and The Hitchhiker's Guide to the Galaxy. You're the fun one in the office - warm, witty, and genuinely helpful. You're never defensive about your opinions and you're quick to acknowledge when someone makes a good point.
 
           PR Title: $PR_TITLE
+          
+          $REVIEW_HISTORY
+
           Comment from @$COMMENT_USER:
           $COMMENT_BODY
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ src/
 │   ├── substrate-api.ts  # Search and people APIs (Substrate v2)
 │   ├── chatsvc-api.ts    # Messaging, threads, save/unsave (chatsvc)
 │   ├── csa-api.ts        # Favorites API (CSA)
-│   └── calendar-api.ts   # Calendar/meetings API
+│   ├── calendar-api.ts   # Calendar/meetings API
+│   └── transcript-api.ts # Meeting transcripts (Graph API)
 ├── browser/              # Playwright browser automation (login only)
 │   ├── context.ts        # Browser/context management with encrypted session
 │   └── auth.ts           # Authentication detection and manual login handling
@@ -136,6 +137,7 @@ Different Teams APIs use different authentication mechanisms:
 | **Favorites** (csa/conversationFolders) | CSA token from MSAL + `skypetoken_asm` | `auth/token-extractor` | `extractCsaToken()` + `extractMessageAuth()` |
 | **Threads** (chatsvc) | `skypetoken_asm` cookie | `auth/token-extractor` | `extractMessageAuth()` |
 | **Calendar** (mt/part/calendarView) | Skype Spaces token (`api.spaces.skype.com` scope) + `skypetoken_asm` | `auth/token-extractor` | `extractSkypeSpacesToken()` |
+| **Transcripts** (Substrate WorkingSetFiles) | Same JWT as Search (Substrate scope) + `Prefer` header | `auth/token-extractor` | `getValidSubstrateToken()` |
 
 **Important**: The CSA API (for favorites) requires a GET request to retrieve data, POST only for modifications. The Substrate suggestions API requires `cvid` and `logicalId` correlation IDs in the request body.
 
@@ -186,6 +188,7 @@ Session state and token cache files are protected by:
 | `teams_add_reaction` | Add an emoji reaction to a message |
 | `teams_remove_reaction` | Remove an emoji reaction from a message |
 | `teams_get_meetings` | Get meetings from calendar (upcoming/past by date range) |
+| `teams_get_transcript` | Get meeting transcript (requires threadId from teams_get_meetings) |
 
 ### Design Philosophy
 

--- a/README.md
+++ b/README.md
@@ -121,13 +121,14 @@ The server uses your system's Chrome (macOS/Linux) or Edge (Windows) for authent
 
 **Quick reactions:** `like`, `heart`, `laugh`, `surprised`, `sad`, `angry` can be used directly without searching.
 
-### Calendar
+### Calendar & Meetings
 
 | Tool | Description |
 |------|-------------|
 | `teams_get_meetings` | Get meetings from calendar (defaults to next 7 days) |
+| `teams_get_transcript` | Get meeting transcript (requires `threadId` from `teams_get_meetings`) |
 
-Returns: subject, times, organiser, join URL, `threadId` for meeting chat. Use with `teams_get_thread` to read meeting discussions.
+`teams_get_meetings` returns: subject, times, organiser, join URL, `threadId` for meeting chat. Use `threadId` with `teams_get_thread` to read meeting chat, or with `teams_get_transcript` to get the full transcript with speakers and timestamps.
 
 ### Session
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,14 +2,14 @@
 
 | Priority | Feature | Description | Difficulty | Notes |
 |----------|---------|-------------|------------|-------|
-| ~~Bug~~ | ~~Message formatting~~ | ~~Fixed: markdownToTeamsHtml converts markdown to Teams HTML (bold, italic, strikethrough, code, lists, newlines)~~ | ~~Medium~~ | ~~Done~~ |
-| P2 | Meeting transcripts | Retrieve meeting transcripts | Hard | Extends existing meeting tools; needs research into transcript API surface |
+| Bug | Message links unreliable | Deep links sometimes fail with "can't find" error when Teams opens | Medium | Investigate link format variations - may be threading/context related |
+| Done | Meeting transcripts | Retrieve meeting transcripts via `teams_get_transcript` | Hard | Uses Substrate WorkingSetFiles API: threadId → filter by MeetingThreadId → parse embedded TranscriptJson |
 | P2 | Meeting attendees | Filter meetings by attendee (not just organiser) | Medium | Need to research attendee list in calendar API response |
 | P2 | Find team | Search/discover teams by name | Easy | Teams List API |
 | P2 | Get person details | Detailed profile info (working hours, OOO status) | Easy | Delve API |
 | P2 | Get shared files | Files shared in a conversation | Medium | AllFiles API |
-| P3 | Meeting recordings | Locate recordings/transcripts | Hard | Needs research |
+| P2 | AI meeting summary | Retrieve Copilot/Intelligent Recap summary for meetings | Hard | Endpoint identified: `substrate.office.com/search/api/v1/recommendations` with scenario `MeetingCatchup.MeetApp`. Needs research to capture full summary content and check Copilot license requirement |
+| P3 | Meeting recordings | Locate recordings/transcripts | Medium | Recording URL available in WorkingSetFiles response (`SharePointItem.FileUrl`) — could expose alongside transcript |
 | P3 | Region auto-detection | Detect user's API region (amer/emea/apac) from session instead of defaulting to amer | Easy | Could extract from browser session or make configurable via env var |
 | P3 | Verify Skype token refresh | Check whether the messaging token (skypetoken_asm) gets refreshed during auto token refresh, or only the Substrate token | Easy | Add before/after logging to `refreshTokensViaBrowser()` to compare both tokens |
 | P3 | Get message by URL | Fetch a specific message from a Teams link with surrounding context | Medium | Parse URL to extract conversation/message IDs, return target message plus N messages before/after |
-| Bug | Message links unreliable | Deep links sometimes fail with "can't find" error when Teams opens | Medium | Investigate link format variations - may be threading/context related |

--- a/docs/MANUAL-TEST-SCRIPT.md
+++ b/docs/MANUAL-TEST-SCRIPT.md
@@ -57,6 +57,12 @@ This is a test script for verifying all MCP tools work correctly before release.
 | `teams_remove_reaction` | Remove an emoji reaction from a message |
 | `teams_search_emoji` | Search for emojis by name (standard + custom org emojis) |
 
+### Calendar & Meetings
+| Tool | Purpose |
+|------|---------|
+| `teams_get_meetings` | Get meetings from calendar (defaults to next 7 days, set startDate to past for recent) |
+| `teams_get_transcript` | Get meeting transcript (requires threadId from teams_get_meetings) |
+
 ### Favourites
 | Tool | Purpose |
 |------|---------|
@@ -160,6 +166,14 @@ When reading channel messages with `teams_get_thread`:
 2. teams_get_thread conversationId="sourceConversationId" → read thread content
 ```
 
+### Get a meeting transcript
+```
+1. teams_get_meetings startDate="past date" → find the meeting, get threadId
+2. teams_get_transcript threadId="19:meeting_xxx@thread.v2" meetingDate="startTime from step 1"
+```
+Returns: meeting title, speakers list, entry count, and full formatted transcript with timestamps.
+Note: Only works for meetings where transcription was enabled.
+
 ### React to a message
 ```
 1. teams_search or teams_get_thread → find the message
@@ -207,6 +221,9 @@ Quick reactions: `like` (👍), `heart` (❤️), `laugh` (😂), `surprised` (�
 
 ### Channel monitoring
 > "Check the [channel name] channel for recent activity and summarise any important updates."
+
+### Meeting transcript
+> "Get the transcript from my last standup meeting and summarise the key decisions."
 
 ### People lookup
 > "Find [person name]'s contact details and check if I have any recent conversations with them."

--- a/docs/USER-STORIES.md
+++ b/docs/USER-STORIES.md
@@ -589,16 +589,18 @@ This document defines user stories and personas to guide development of the Team
 **Flow:**
 1. Get recent meetings via `teams_get_meetings` with past date range
 2. Get the meeting thread ID from the response
-3. Fetch chat messages via `teams_get_thread` using the thread ID
-4. AI summarises the meeting discussion
+3. If transcription was enabled: fetch transcript via `teams_get_transcript` using `threadId`
+4. Otherwise: fetch chat messages via `teams_get_thread` using the thread ID
+5. AI summarises the meeting from transcript or chat
 
 **Required Tools:**
 | Tool | Status |
 |------|--------|
 | `teams_get_meetings` | ✅ Implemented |
-| `teams_get_thread` | ✅ Implemented |
+| `teams_get_transcript` | ✅ Implemented |
+| `teams_get_thread` | ✅ Implemented (fallback for meetings without transcription) |
 
-**Status:** ✅ Implemented - set `startDate` to past to get recent meetings, then use `threadId` with `teams_get_thread`.
+**Status:** ✅ Implemented - set `startDate` to past to get recent meetings. Use `teams_get_transcript` for full transcript with speakers/timestamps, or `teams_get_thread` for meeting chat.
 
 ---
 
@@ -673,7 +675,26 @@ This document defines user stories and personas to guide development of the Team
 
 ---
 
-#### 9.8 Check free time
+#### 9.8 Get meeting transcript
+> "Get the transcript from yesterday's standup"
+
+**Flow:**
+1. Get recent meetings via `teams_get_meetings` with past date range
+2. Identify the target meeting, get its `threadId` and `startTime`
+3. Fetch transcript via `teams_get_transcript` with `threadId` and optionally `meetingDate`
+4. AI presents or summarises the transcript
+
+**Required Tools:**
+| Tool | Status |
+|------|--------|
+| `teams_get_meetings` | ✅ Implemented |
+| `teams_get_transcript` | ✅ Implemented |
+
+**Status:** ✅ Implemented - returns formatted transcript with speaker names, timestamps, and spoken text. Only available for meetings where transcription was enabled.
+
+---
+
+#### 9.9 Check free time
 > "When am I free this afternoon?"
 
 **Flow:**
@@ -892,7 +913,8 @@ Based on user value and API readiness:
 | 9.2 Count meetings | `teams_get_meetings` | ✅ Done |
 | 9.3 Meeting summary | `teams_get_meetings`, `teams_get_thread` | ✅ Done |
 | 9.4 Meetings with person | `teams_get_meetings`, `teams_search_people` | ✅ Done (organiser only) |
-| 9.5-9.8 Other meeting stories | `teams_get_meetings` | ✅ Done |
+| 9.5-9.7, 9.9 Other meeting stories | `teams_get_meetings` | ✅ Done |
+| 9.8 Meeting transcript | `teams_get_meetings`, `teams_get_transcript` | ✅ Done |
 
 ### Phase 5 - Remaining Gaps
 | Story | Tools Needed | Effort |
@@ -941,8 +963,9 @@ The following tools are implemented:
 **Chat Management:**
 - `teams_get_chat` - Get 1:1 conversation ID
 
-**Calendar:**
+**Calendar & Meetings:**
 - `teams_get_meetings` - Get meetings from calendar
+- `teams_get_transcript` - Get meeting transcript (speakers, timestamps, text)
 
 ### Remaining Gaps
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,3 +6,4 @@ export * from './substrate-api.js';
 export * from './chatsvc-api.js';
 export * from './csa-api.js';
 export * from './calendar-api.js';
+export * from './transcript-api.js';

--- a/src/api/transcript-api.ts
+++ b/src/api/transcript-api.ts
@@ -1,0 +1,182 @@
+/**
+ * Transcript API client for meeting transcript operations.
+ * 
+ * Uses Substrate WorkingSetFiles API to fetch meeting transcripts.
+ * The transcript is embedded as JSON in the WorkingSetFiles response,
+ * using the same Substrate token already used for search.
+ * 
+ * Flow: threadId → Substrate WorkingSetFiles (filter by MeetingThreadId) → parse TranscriptJson
+ */
+
+import { httpRequest } from '../utils/http.js';
+import { type Result, ok, err } from '../types/result.js';
+import { ErrorCode, createError } from '../types/errors.js';
+import { requireSubstrateTokenAsync } from '../utils/auth-guards.js';
+import { formatTranscriptText, type TranscriptEntry } from '../utils/parsers.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Result of fetching a transcript. */
+export interface TranscriptResult {
+  /** Meeting title from the recording metadata. */
+  meetingTitle?: string;
+  /** Meeting thread ID used for the lookup. */
+  threadId: string;
+  /** When the recording started. */
+  recordingStartTime?: string;
+  /** When the recording ended. */
+  recordingEndTime?: string;
+  /** Parsed transcript entries with timestamps and speakers. */
+  entries: TranscriptEntry[];
+  /** Formatted readable transcript text. */
+  formattedText: string;
+  /** Number of transcript entries. */
+  entryCount: number;
+  /** List of unique speakers in the transcript. */
+  speakers: string[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Substrate WorkingSetFiles endpoint for finding meeting recordings + transcripts. */
+const WORKING_SET_FILES_URL = 'https://substrate.office.com/api/beta/me/WorkingSetFiles/';
+
+/** Fields to select from WorkingSetFiles. */
+const WORKING_SET_SELECT = [
+  'SharePointItem',
+  'Visualization',
+  'ItemProperties/Default/MeetingCallId',
+  'ItemProperties/Default/DriveId',
+  'ItemProperties/Default/RecordingStartDateTime',
+  'ItemProperties/Default/RecordingEndDateTime',
+  'ItemProperties/Default/TranscriptJson',
+  'ItemProperties/Default/DocumentLink',
+].join(',');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// API Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Gets the transcript for a meeting by its thread ID.
+ * 
+ * Uses Substrate WorkingSetFiles to find the recording associated with the
+ * meeting thread, then extracts the embedded TranscriptJson.
+ * 
+ * @param threadId - The meeting thread ID (e.g., "19:meeting_xxx@thread.v2")
+ * @param meetingDate - ISO date string of the meeting (used to narrow the search window)
+ * @returns Parsed transcript with entries and formatted text
+ */
+export async function getTranscriptContent(
+  threadId: string,
+  meetingDate?: string
+): Promise<Result<TranscriptResult>> {
+  const authResult = await requireSubstrateTokenAsync();
+  if (!authResult.ok) return authResult;
+  const token = authResult.value;
+
+  // Build date filter: search ±1 day around the meeting date, or last 30 days
+  let dateFilter = '';
+  if (meetingDate) {
+    const date = new Date(meetingDate);
+    const dayBefore = new Date(date);
+    dayBefore.setDate(dayBefore.getDate() - 1);
+    const dayAfter = new Date(date);
+    dayAfter.setDate(dayAfter.getDate() + 1);
+    dateFilter = ` AND FileCreatedTime gt ${dayBefore.toISOString()} AND FileCreatedTime lt ${dayAfter.toISOString()}`;
+  }
+
+  const filter = `ItemProperties/Default/MeetingThreadId eq '${threadId}'${dateFilter}`;
+  const url = `${WORKING_SET_FILES_URL}?$filter=${encodeURIComponent(filter)}&$orderby=${encodeURIComponent('FileCreatedTime desc')}&$select=${encodeURIComponent(WORKING_SET_SELECT)}`;
+
+  const response = await httpRequest<Record<string, unknown>>(
+    url,
+    {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Prefer': 'substrate.flexibleschema,outlook.data-source="Substrate",exchange.behavior="SubstrateFiles"',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    return response;
+  }
+
+  const data = response.value.data;
+  const items = data.value as Array<Record<string, unknown>> | undefined;
+
+  if (!items || items.length === 0) {
+    return err(createError(
+      ErrorCode.NOT_FOUND,
+      'No recording found for this meeting. Transcription may not have been enabled, or the recording has not finished processing.',
+      { suggestions: [
+        'Check that transcription/recording was enabled during the meeting',
+        'Wait a few minutes if the meeting just ended',
+        'The meeting organiser must have recording enabled',
+      ] }
+    ));
+  }
+
+  const item = items[0];
+  const props = (item.ItemProperties as Record<string, unknown>)?.Default as Record<string, unknown> | undefined;
+  const viz = item.Visualization as Record<string, unknown> | undefined;
+
+  // Extract TranscriptJson
+  const transcriptJsonStr = props?.TranscriptJson as string | undefined;
+  if (!transcriptJsonStr) {
+    return err(createError(
+      ErrorCode.NOT_FOUND,
+      'Recording found but no transcript available. Transcription may not have been enabled for this meeting.',
+      { suggestions: ['Check that transcription was enabled during the meeting'] }
+    ));
+  }
+
+  // Parse the transcript JSON
+  let transcriptData: { entries?: Array<Record<string, unknown>> };
+  try {
+    transcriptData = JSON.parse(transcriptJsonStr);
+  } catch {
+    return err(createError(
+      ErrorCode.UNKNOWN,
+      'Failed to parse transcript data.',
+    ));
+  }
+
+  const rawEntries = transcriptData.entries || [];
+  if (rawEntries.length === 0) {
+    return err(createError(
+      ErrorCode.NOT_FOUND,
+      'Transcript is empty — no speech was detected during the meeting.',
+    ));
+  }
+
+  // Map to TranscriptEntry format
+  const entries: TranscriptEntry[] = rawEntries.map(e => ({
+    startTime: (e.startOffset as string || '').replace(/0{4}$/, ''),
+    endTime: (e.endOffset as string || '').replace(/0{4}$/, ''),
+    speaker: e.speakerDisplayName as string || '',
+    text: e.text as string || '',
+  }));
+
+  const formattedText = formatTranscriptText(entries);
+  const speakers = [...new Set(entries.map(e => e.speaker).filter(s => s.length > 0))];
+
+  return ok({
+    meetingTitle: viz?.Title as string | undefined,
+    threadId,
+    recordingStartTime: props?.RecordingStartDateTime as string | undefined,
+    recordingEndTime: props?.RecordingEndDateTime as string | undefined,
+    entries,
+    formattedText,
+    entryCount: entries.length,
+    speakers,
+  });
+}

--- a/src/api/transcript-api.ts
+++ b/src/api/transcript-api.ts
@@ -143,10 +143,10 @@ export async function getTranscriptContent(
   let transcriptData: { entries?: Array<Record<string, unknown>> };
   try {
     transcriptData = JSON.parse(transcriptJsonStr);
-  } catch {
+  } catch (parseError) {
     return err(createError(
       ErrorCode.UNKNOWN,
-      'Failed to parse transcript data.',
+      `Failed to parse transcript data: ${parseError instanceof Error ? parseError.message : 'unknown error'}`,
     ));
   }
 
@@ -159,6 +159,7 @@ export async function getTranscriptContent(
   }
 
   // Map to TranscriptEntry format
+  // Substrate returns timestamps with microsecond precision (extra 4 trailing zeros) — normalise to milliseconds
   const entries: TranscriptEntry[] = rawEntries.map(e => ({
     startTime: (e.startOffset as string || '').replace(/0{4}$/, ''),
     endTime: (e.endOffset as string || '').replace(/0{4}$/, ''),

--- a/src/research/explore.ts
+++ b/src/research/explore.ts
@@ -263,7 +263,7 @@ async function main(): Promise<void> {
     if (existingState) {
       console.log('📂 Found existing session state, attempting to restore...');
       context = await browser.newContext({
-        storageState: existingState as Parameters<typeof browser.newContext>[0] extends { storageState?: infer S } ? S : never,
+        storageState: existingState as any,
         viewport: { width: 1280, height: 800 },
       });
     } else {

--- a/src/research/explore.ts
+++ b/src/research/explore.ts
@@ -12,12 +12,9 @@
 import { chromium, type Browser, type BrowserContext, type Page, type Request, type Response } from 'playwright';
 import * as fs from 'fs';
 import * as path from 'path';
-import { fileURLToPath } from 'url';
 import {
   PROJECT_ROOT,
   USER_DATA_DIR,
-  SESSION_STATE_PATH,
-  hasSessionState,
   readSessionState,
   writeSessionState,
 } from '../auth/session-store.js';
@@ -266,7 +263,7 @@ async function main(): Promise<void> {
     if (existingState) {
       console.log('📂 Found existing session state, attempting to restore...');
       context = await browser.newContext({
-        storageState: existingState as any,
+        storageState: existingState as Parameters<typeof browser.newContext>[0] extends { storageState?: infer S } ? S : never,
         viewport: { width: 1280, height: 800 },
       });
     } else {
@@ -295,7 +292,7 @@ async function main(): Promise<void> {
       // Save session state after successful authentication
       console.log('💾 Saving session state...');
       const state = await context.storageState();
-      writeSessionState(state as any);
+      writeSessionState(state as ReturnType<typeof JSON.parse>);
       console.log('✅ Session state saved!');
     } else {
       console.log('✅ Already authenticated!');
@@ -329,7 +326,7 @@ async function main(): Promise<void> {
     try {
       console.log('💾 Saving final session state...');
       const finalState = await context.storageState();
-      writeSessionState(finalState as any);
+      writeSessionState(finalState as ReturnType<typeof JSON.parse>);
     } catch {
       console.log('⚠️  Could not save session state (browser already closed)');
     }

--- a/src/tools/meeting-tools.ts
+++ b/src/tools/meeting-tools.ts
@@ -81,7 +81,7 @@ async function handleGetMeetings(
 
 const getTranscriptToolDefinition: Tool = {
   name: 'teams_get_transcript',
-  description: 'Get the transcript of a Teams meeting. Requires the meeting\'s threadId (from teams_get_meetings). Returns the full transcript with timestamps and speakers, formatted as readable text. The meeting must have had transcription enabled. Optionally pass meetingDate (ISO string, e.g. the startTime from teams_get_meetings) to narrow the search.',
+  description: 'Get the transcript of a Teams meeting. Requires the meeting\'s threadId (from teams_get_meetings). Returns formatted transcript text with timestamps and speaker names, ready for reading or summarization. The meeting must have had transcription enabled. Optionally pass meetingDate (ISO string, e.g. the startTime from teams_get_meetings) to narrow the search.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/utils/parsers.test.ts
+++ b/src/utils/parsers.test.ts
@@ -23,6 +23,7 @@ import {
   decodeBase64Guid,
   extractActivityTimestamp,
   markdownToTeamsHtml,
+  formatTranscriptText,
 } from './parsers.js';
 import {
   searchResultItem,
@@ -762,5 +763,42 @@ describe('markdownToTeamsHtml', () => {
 
   it('handles whitespace-only input', () => {
     expect(markdownToTeamsHtml('   ')).toBe('<p></p>');
+  });
+});
+
+describe('formatTranscriptText', () => {
+  it('formats entries with speaker names and timestamps', () => {
+    const entries = [
+      { startTime: '00:00:01.000', endTime: '00:00:05.000', speaker: 'Alice', text: 'Hello everyone.' },
+      { startTime: '00:00:06.000', endTime: '00:00:10.000', speaker: 'Bob', text: 'Hi Alice!' },
+    ];
+    const result = formatTranscriptText(entries);
+    expect(result).toBe(
+      '[00:00:01.000] Alice:\nHello everyone.\n\n[00:00:06.000] Bob:\nHi Alice!'
+    );
+  });
+
+  it('merges consecutive entries from the same speaker', () => {
+    const entries = [
+      { startTime: '00:00:01.000', endTime: '00:00:03.000', speaker: 'Alice', text: 'First part.' },
+      { startTime: '00:00:03.000', endTime: '00:00:06.000', speaker: 'Alice', text: 'Second part.' },
+      { startTime: '00:00:07.000', endTime: '00:00:10.000', speaker: 'Bob', text: 'Response.' },
+    ];
+    const result = formatTranscriptText(entries);
+    expect(result).toBe(
+      '[00:00:01.000] Alice:\nFirst part. Second part.\n\n[00:00:07.000] Bob:\nResponse.'
+    );
+  });
+
+  it('handles entries without speaker names', () => {
+    const entries = [
+      { startTime: '00:00:01.000', endTime: '00:00:05.000', speaker: '', text: 'Unknown speaker.' },
+    ];
+    const result = formatTranscriptText(entries);
+    expect(result).toBe('[00:00:01.000]\nUnknown speaker.');
+  });
+
+  it('returns empty string for empty entries', () => {
+    expect(formatTranscriptText([])).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

Add a new `teams_get_transcript` tool to retrieve meeting transcripts using the Substrate WorkingSetFiles API. This uses the same authentication as search (Substrate token) — **no Azure App registration or admin consent required**.

## How it works

```
threadId → Substrate WorkingSetFiles (filter by MeetingThreadId) → parse embedded TranscriptJson
```

The Teams web app stores meeting recordings on SharePoint/OneDrive. The Substrate WorkingSetFiles API indexes these files with meeting metadata, including the **full transcript JSON** embedded in `ItemProperties.Default.TranscriptJson`. This means the transcript is retrieved in a **single API call**.

### Key details
- **Endpoint**: `GET https://substrate.office.com/api/beta/me/WorkingSetFiles/`
- **Auth**: Same Substrate Bearer token used for search
- **Critical header**: `Prefer: substrate.flexibleschema,outlook.data-source="Substrate",exchange.behavior="SubstrateFiles"`
- **Input**: `threadId` (from `teams_get_meetings`) + optional `meetingDate`
- **Output**: meeting title, speakers list, entry count, formatted transcript with timestamps

### Usage
```
1. teams_get_meetings startDate="past date" → find meeting, get threadId
2. teams_get_transcript threadId="19:meeting_xxx@thread.v2"
```

## Testing

- ✅ Build passes (`npm run build`)
- ✅ 114 unit tests pass (`npm test`)
- ✅ Live-tested: retrieved a 280-entry (22KB) transcript from a real meeting
- ✅ CLI test harness end-to-end: `teams_search` → find threadId → `teams_get_transcript` → full transcript

## Files changed

| File | Change |
|------|--------|
| `src/api/transcript-api.ts` | **New** — Substrate WorkingSetFiles API client |
| `src/tools/meeting-tools.ts` | Add `teams_get_transcript` tool definition + handler |
| `src/utils/parsers.ts` | Add `TranscriptEntry` type + `formatTranscriptText()` |
| `src/utils/parsers.test.ts` | 4 unit tests for `formatTranscriptText` |
| `src/api/index.ts` | Export new module |
| `src/research/explore.ts` | Capture transcript-related network patterns |
| `AGENTS.md` | Auth table + tool table |
| `README.md` | Calendar & Meetings tools section |
| `ROADMAP.md` | Mark transcript done, add AI summary item |
| `docs/API-REFERENCE.md` | Full WorkingSetFiles API documentation |
| `docs/MANUAL-TEST-SCRIPT.md` | Transcript test workflow + example prompt |
| `docs/USER-STORIES.md` | Story 9.8 + updated implementation status |
