### PR TITLE
fix: reliable message deep links per Microsoft docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ src/
    - Easier testing of individual tools
    - Simpler addition of new tools
 
-8. **Auth Guards**: Reusable authentication check utilities in `utils/auth-guards.ts` return `Result` types for consistent error handling across API modules.
+8. **Auth Guards**: Reusable authentication check utilities in `utils/auth-guards.ts` return `Result` types for consistent error handling across API modules. Also provides `getTenantId()` (cached) for deep link construction.
 
 9. **Shared Constants**: Magic numbers are centralised in `constants.ts` for maintainability (page sizes, timeouts, thresholds).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 | Priority | Feature | Description | Difficulty | Notes |
 |----------|---------|-------------|------------|-------|
-| Bug | Message links unreliable | Deep links sometimes fail with "can't find" error when Teams opens | Medium | Investigate link format variations - may be threading/context related |
+| ~~Bug~~ | ~~Message links unreliable~~ | ~~Fixed: added tenantId, groupId, parentMessageId, createdTime per MS docs~~ | ~~Medium~~ | ~~Was missing required query params for channel and chat deep links~~ |
 | P3 | Meeting attendees | Filter meetings by attendee (not just organiser) | Medium | Need to research attendee list in calendar API response |
 | P3 | Find team | Search/discover teams by name | Easy | Teams List API |
 | P3 | Get person details | Detailed profile info (working hours, OOO status) | Easy | Delve API |

--- a/src/api/substrate-api.ts
+++ b/src/api/substrate-api.ts
@@ -9,7 +9,7 @@ import { SUBSTRATE_API, getBearerHeaders } from '../utils/api-config.js';
 import { ErrorCode } from '../types/errors.js';
 import { type Result, ok } from '../types/result.js';
 import { clearTokenCache } from '../auth/token-extractor.js';
-import { requireSubstrateTokenAsync } from '../utils/auth-guards.js';
+import { requireSubstrateTokenAsync, getTenantId, getTeamsBaseUrl } from '../utils/auth-guards.js';
 import {
   parseSearchResults,
   parsePeopleResults,
@@ -17,6 +17,7 @@ import {
   filterChannelsByName,
   type PersonSearchResult,
   type ChannelSearchResult,
+  type LinkContext,
 } from '../utils/parsers.js';
 import { getMyTeamsAndChannels } from './csa-api.js';
 import type { TeamsSearchResult, SearchPaginationResult } from '../types/teams.js';
@@ -106,8 +107,13 @@ export async function searchMessages(
   }
 
   const data = response.value.data;
+  const linkContext: LinkContext = {
+    tenantId: getTenantId() ?? undefined,
+    teamsBaseUrl: getTeamsBaseUrl(),
+  };
   const { results, total } = parseSearchResults(
-    data.EntitySets as unknown[] | undefined
+    data.EntitySets as unknown[] | undefined,
+    linkContext
   );
 
   const maxResults = options.maxResults ?? size;

--- a/src/utils/auth-guards.ts
+++ b/src/utils/auth-guards.ts
@@ -14,6 +14,7 @@ import {
   extractSubstrateToken,
   extractSkypeSpacesToken,
   extractRegionConfig,
+  getUserProfile,
   type MessageAuthInfo,
   type RegionConfig,
 } from '../auth/token-extractor.js';
@@ -195,9 +196,33 @@ export function getRegionConfig(): RegionConfig | null {
 }
 
 /**
- * Clears the cached region config.
+ * Clears the cached region config and tenant ID.
  * Call this after login/logout to pick up new session.
  */
 export function clearRegionCache(): void {
   cachedRegionConfig = null;
+  cachedTenantId = undefined;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tenant ID
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Cached tenant ID (undefined = not yet extracted, null = extraction failed). */
+let cachedTenantId: string | null | undefined = undefined;
+
+/**
+ * Gets the tenant ID from the user's session (JWT tokens).
+ * 
+ * Required for building reliable Teams deep links.
+ * Returns null if no valid session is available.
+ */
+export function getTenantId(): string | null {
+  if (cachedTenantId !== undefined) {
+    return cachedTenantId;
+  }
+  const profile = getUserProfile();
+  const tid = profile?.tenantId ?? null;
+  cachedTenantId = tid;
+  return tid;
 }

--- a/src/utils/auth-guards.ts
+++ b/src/utils/auth-guards.ts
@@ -153,8 +153,8 @@ import { DEFAULT_TEAMS_BASE_URL } from './api-config.js';
 /** Default region when session config is unavailable. */
 const DEFAULT_REGION = 'amer';
 
-/** Cached region config to avoid repeated localStorage parsing. */
-let cachedRegionConfig: RegionConfig | null = null;
+/** Cached region config (undefined = not yet extracted, null = extraction failed). */
+let cachedRegionConfig: RegionConfig | null | undefined = undefined;
 
 /**
  * Gets the user's region from session, with caching.
@@ -163,7 +163,7 @@ let cachedRegionConfig: RegionConfig | null = null;
  * Falls back to 'amer' if not available (shouldn't happen with valid session).
  */
 export function getRegion(): string {
-  if (!cachedRegionConfig) {
+  if (cachedRegionConfig === undefined) {
     cachedRegionConfig = extractRegionConfig();
   }
   return cachedRegionConfig?.region ?? DEFAULT_REGION;
@@ -177,7 +177,7 @@ export function getRegion(): string {
  * Falls back to default if config not available.
  */
 export function getTeamsBaseUrl(): string {
-  if (!cachedRegionConfig) {
+  if (cachedRegionConfig === undefined) {
     cachedRegionConfig = extractRegionConfig();
   }
   return cachedRegionConfig?.teamsBaseUrl ?? DEFAULT_TEAMS_BASE_URL;
@@ -189,7 +189,7 @@ export function getTeamsBaseUrl(): string {
  * Returns null if no valid session - caller should handle auth error.
  */
 export function getRegionConfig(): RegionConfig | null {
-  if (!cachedRegionConfig) {
+  if (cachedRegionConfig === undefined) {
     cachedRegionConfig = extractRegionConfig();
   }
   return cachedRegionConfig;
@@ -200,7 +200,7 @@ export function getRegionConfig(): RegionConfig | null {
  * Call this after login/logout to pick up new session.
  */
 export function clearRegionCache(): void {
-  cachedRegionConfig = null;
+  cachedRegionConfig = undefined;
   cachedTenantId = undefined;
 }
 


### PR DESCRIPTION
## Problem

Message deep links were unreliable — Teams would sometimes show a "can't find" error when opening them. This was the first item on the ROADMAP.

## Root Causes

After researching [Microsoft's deep link documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/deep-link-teams), I found we were missing several required query parameters:

1. **Channel links missing `tenantId`, `groupId`, `parentMessageId`, `createdTime`** — MS requires all of these for channel message deep links
2. **Chat/meeting links missing `tenantId`** — Required per MS docs alongside the `context` parameter
3. **`parentMessageId` not always present for channels** — MS docs show it's required even for top-level posts (where it equals the messageId)

### Expected format (per MS docs)

**Channel messages:**
```
/l/message/{channelId}/{msgId}?tenantId=...&groupId=...&parentMessageId=...&createdTime=...
```

**Chat/meeting messages:**
```
/l/message/{chatId}/{msgId}?tenantId=...&context={"contextType":"chat"}
```

## Changes

### Core fix: `buildMessageLink()` in `parsers.ts`
- New `MessageLinkOptions` interface with `tenantId`, `groupId`, `parentMessageId`, `teamsBaseUrl`
- Channel links now always include `parentMessageId` (defaults to messageId for top-level posts) and `createdTime`
- Chat/meeting links now include `tenantId` alongside the `context` parameter
- Old positional API kept as deprecated overload for backwards compatibility

### New helper: `getTenantId()` in `auth-guards.ts`
- Extracts tenant ID from JWT tokens in session state
- Cached after first extraction (cleared on login/logout)

### Updated callers (all now pass `tenantId` + `teamsBaseUrl`)
- **`getThread()`** — thread message links
- **`getActivityFeed()`** — activity feed links  
- **`getSavedMessages()`** — saved message links
- **`getFollowedThreads()`** — followed thread links
- **`searchMessages()`** — search result links (via `LinkContext` interface)

### Tests
- 117 tests passing (was 114, added 3 new tests for options-object API)
- Tests for `tenantId`/`groupId` params, GCC base URL support

## Files changed
- `src/utils/parsers.ts` — Core `buildMessageLink` rewrite + `LinkContext` interface
- `src/utils/parsers.test.ts` — Updated + new tests
- `src/utils/auth-guards.ts` — New `getTenantId()` helper
- `src/api/chatsvc-api.ts` — All link-building callers updated
- `src/api/substrate-api.ts` — Search results pass `linkContext`
- `AGENTS.md` / `ROADMAP.md` — Documentation updates