### PR TITLE
feat: add teams_get_shared_files tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ src/
 │   ├── message-tools.ts  # Messaging, favourites, save/unsave tools
 │   ├── people-tools.ts   # People search and profile tools
 │   ├── meeting-tools.ts  # Calendar and meeting tools
+│   ├── file-tools.ts     # Shared files tools
 │   └── auth-tools.ts     # Login and status tools
 ├── auth/                 # Authentication and credential management
 │   ├── index.ts          # Module exports
@@ -40,7 +41,8 @@ src/
 │   ├── chatsvc-api.ts    # Messaging, threads, save/unsave (chatsvc)
 │   ├── csa-api.ts        # Favorites API (CSA)
 │   ├── calendar-api.ts   # Calendar/meetings API
-│   └── transcript-api.ts # Meeting transcripts (Graph API)
+│   ├── transcript-api.ts # Meeting transcripts (Substrate WorkingSetFiles)
+│   └── files-api.ts      # Shared files (Substrate AllFiles)
 ├── browser/              # Playwright browser automation (login only)
 │   ├── context.ts        # Browser/context management with encrypted session
 │   └── auth.ts           # Authentication detection and manual login handling
@@ -138,6 +140,7 @@ Different Teams APIs use different authentication mechanisms:
 | **Threads** (chatsvc) | `skypetoken_asm` cookie | `auth/token-extractor` | `extractMessageAuth()` |
 | **Calendar** (mt/part/calendarView) | Skype Spaces token (`api.spaces.skype.com` scope) + `skypetoken_asm` | `auth/token-extractor` | `extractSkypeSpacesToken()` |
 | **Transcripts** (Substrate WorkingSetFiles) | Same JWT as Search (Substrate scope) + `Prefer` header | `auth/token-extractor` | `getValidSubstrateToken()` |
+| **Files** (Substrate AllFiles) | Same JWT as Search (Substrate scope) + message auth for user MRI | `auth/token-extractor` | `getValidSubstrateToken()` + `extractMessageAuth()` |
 
 **Important**: The CSA API (for favorites) requires a GET request to retrieve data, POST only for modifications. The Substrate suggestions API requires `cvid` and `logicalId` correlation IDs in the request body.
 
@@ -189,6 +192,7 @@ Session state and token cache files are protected by:
 | `teams_remove_reaction` | Remove an emoji reaction from a message |
 | `teams_get_meetings` | Get meetings from calendar (upcoming/past by date range) |
 | `teams_get_transcript` | Get meeting transcript (requires threadId from teams_get_meetings) |
+| `teams_get_shared_files` | Get files and links shared in a conversation |
 
 ### Design Philosophy
 
@@ -422,7 +426,6 @@ Based on API research, these tools could be implemented:
 | Tool | API | Difficulty |
 |------|-----|------------|
 | `teams_get_person` | Delve person API | Easy |
-| `teams_get_files` | AllFiles API | Medium |
 
 **Known Limitations:**
 - **Chat list** - Partially addressed by `teams_get_favorites` (pinned chats) and `teams_get_frequent_contacts` (common contacts), but no full chat list API

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,8 +2,7 @@
 
 | Priority | Feature | Description | Difficulty | Notes |
 |----------|---------|-------------|------------|-------|
-| P3 | Meeting attendees | Filter meetings by attendee (not just organiser) | Medium | Need to research attendee list in calendar API response |
 | P3 | Find team | Search/discover teams by name | Easy | Teams List API |
 | P3 | Get person details | Detailed profile info (working hours, OOO status) | Easy | Delve API |
-| P2 | Get shared files | Files shared in a conversation | Medium | AllFiles API |requirement |
 | P3 | Get message by URL | Fetch a specific message from a Teams link with surrounding context | Medium | Parse URL to extract conversation/message IDs, return target message plus N messages before/after |
+| P4 | Meeting attendees | Filter meetings by attendee (not just organiser) | Medium | Need to research attendee list in calendar API response |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msteams-mcp",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "MCP server for Microsoft Teams - search messages, send replies, manage favourites",
   "type": "module",
   "main": "dist/index.js",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,3 +7,4 @@ export * from './chatsvc-api.js';
 export * from './csa-api.js';
 export * from './calendar-api.js';
 export * from './transcript-api.js';
+export * from './files-api.js';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -158,6 +158,16 @@ export const DEFAULT_MEETING_LIMIT = 50;
 export const MAX_MEETING_LIMIT = 200;
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Files
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Default page size for shared files. */
+export const DEFAULT_FILES_PAGE_SIZE = 25;
+
+/** Maximum page size for shared files. */
+export const MAX_FILES_PAGE_SIZE = 100;
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Token Refresh
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/src/tools/file-tools.ts
+++ b/src/tools/file-tools.ts
@@ -1,0 +1,84 @@
+/**
+ * File-related tool handlers.
+ */
+
+import { z } from 'zod';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { RegisteredTool, ToolContext, ToolResult } from './index.js';
+import { handleApiResult } from './index.js';
+import { getSharedFiles } from '../api/files-api.js';
+import {
+  DEFAULT_FILES_PAGE_SIZE,
+  MAX_FILES_PAGE_SIZE,
+} from '../constants.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const GetSharedFilesInputSchema = z.object({
+  conversationId: z.string(),
+  pageSize: z.number().min(1).max(MAX_FILES_PAGE_SIZE).optional().default(DEFAULT_FILES_PAGE_SIZE),
+  skipToken: z.string().optional(),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tool Definitions
+// ─────────────────────────────────────────────────────────────────────────────
+
+const getSharedFilesToolDefinition: Tool = {
+  name: 'teams_get_shared_files',
+  description: 'Get files and links shared in a Teams conversation. Returns file names, URLs, extensions, sizes, and who shared them. Works for channels, group chats, 1:1 chats, and meeting chats. Use the conversationId from other tools (teams_get_favorites, teams_search, teams_find_channel, teams_get_chat). Supports pagination via skipToken for conversations with many files.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      conversationId: {
+        type: 'string',
+        description: 'The conversation ID to get shared files for (e.g., "19:abc@thread.tacv2" for a channel, or a chat conversation ID).',
+      },
+      pageSize: {
+        type: 'number',
+        description: `Number of items per page (default: ${DEFAULT_FILES_PAGE_SIZE}, max: ${MAX_FILES_PAGE_SIZE})`,
+      },
+      skipToken: {
+        type: 'string',
+        description: 'Continuation token from a previous response to get the next page of results.',
+      },
+    },
+    required: ['conversationId'],
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function handleGetSharedFiles(
+  input: z.infer<typeof GetSharedFilesInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  const result = await getSharedFiles(input.conversationId, {
+    pageSize: input.pageSize,
+    skipToken: input.skipToken,
+  });
+
+  return handleApiResult(result, (value) => ({
+    conversationId: value.conversationId,
+    returned: value.returned,
+    files: value.files,
+    ...(value.skipToken ? { skipToken: value.skipToken, hasMore: true } : { hasMore: false }),
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Exports
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const getSharedFilesTool: RegisteredTool<typeof GetSharedFilesInputSchema> = {
+  definition: getSharedFilesToolDefinition,
+  schema: GetSharedFilesInputSchema,
+  handler: handleGetSharedFiles,
+};
+
+/** All file-related tools. */
+export const fileTools = [getSharedFilesTool];

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -68,4 +68,5 @@ export * from './message-tools.js';
 export * from './people-tools.js';
 export * from './auth-tools.js';
 export * from './meeting-tools.js';
+export * from './file-tools.js';
 export * from './registry.js';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -12,6 +12,7 @@ import { messageTools } from './message-tools.js';
 import { peopleTools } from './people-tools.js';
 import { authTools } from './auth-tools.js';
 import { meetingTools } from './meeting-tools.js';
+import { fileTools } from './file-tools.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Registry
@@ -25,6 +26,7 @@ const allTools: RegisteredTool<any>[] = [
   ...peopleTools,
   ...authTools,
   ...meetingTools,
+  ...fileTools,
 ];
 
 /** Lookup map for tools by name. */


### PR DESCRIPTION
## Summary

Implements the **Get shared files** roadmap item (P2) using the Substrate AllFiles API.

### New tool: `teams_get_shared_files`

Returns files and links shared in any Teams conversation — channels, group chats, 1:1 chats, and meeting chats.

**Endpoint:** `GET https://substrate.office.com/AllFiles/api/users('OID:{userId}@{tenantId}')/AllShared?ThreadId={conversationId}&ItemTypes=File&ItemTypes=Link&PageSize=25`

**Auth:** Substrate Bearer token (same as search) + message auth (for user MRI)

### What it returns

- **Files** — name, extension, web URL, size, who shared it, when
- **Links** — URL, title, who shared it, when
- **Pagination** — via `skipToken` continuation token

### Files

**New:**
- `src/api/files-api.ts` — API client for AllFiles endpoint
- `src/tools/file-tools.ts` — MCP tool handler with Zod validation

**Modified:**
- `src/constants.ts` — `DEFAULT_FILES_PAGE_SIZE` (25), `MAX_FILES_PAGE_SIZE` (100)
- `src/tools/registry.ts` — Register `fileTools`
- `src/tools/index.ts` / `src/api/index.ts` — Exports
- `AGENTS.md` — Directory structure, auth table, tool overview
- `ROADMAP.md` — Removed completed item

### Testing

- TypeScript compiles cleanly
- 117 existing tests pass
- 0 lint errors
- Live-tested via CLI — returned 22 files/links from a real channel (mix of File and Link items)