### PR TITLE
refactor: clean code review improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,6 @@ src/
 │   └── result.ts         # Result<T, E> type for explicit error handling
 ├── __fixtures__/
 │   └── api-responses.ts  # Mock API responses for testing
-└── test/                 # Integration test tools (CLI, MCP harness)
 ```
 
 ### Implementation Patterns
@@ -84,16 +83,16 @@ src/
 
 7. **MCP Resources**: Passive resources (`teams://me/profile`, `teams://me/favorites`, `teams://status`) provide context discovery without tool calls.
 
-7. **Tool Registry Pattern**: Tools are organised into logical groups (`search-tools.ts`, `message-tools.ts`, etc.) with a central registry (`tools/registry.ts`). This enables:
+8. **Tool Registry Pattern**: Tools are organised into logical groups (`search-tools.ts`, `message-tools.ts`, etc.) with a central registry (`tools/registry.ts`). This enables:
    - Better separation of concerns
    - Easier testing of individual tools
    - Simpler addition of new tools
 
-8. **Auth Guards**: Reusable authentication check utilities in `utils/auth-guards.ts` return `Result` types for consistent error handling across API modules. Also provides `getTenantId()` (cached) for deep link construction.
+9. **Auth Guards**: Reusable authentication check utilities in `utils/auth-guards.ts` return `Result` types for consistent error handling across API modules. Also provides `getTenantId()` (cached) for deep link construction.
 
-9. **Shared Constants**: Magic numbers are centralised in `constants.ts` for maintainability (page sizes, timeouts, thresholds).
+10. **Shared Constants**: Magic numbers are centralised in `constants.ts` for maintainability (page sizes, timeouts, thresholds).
 
-10. **Markdown to Teams HTML**: Outgoing messages support markdown formatting via `markdownToTeamsHtml()` in `utils/parsers.ts`. This converts markdown (`**bold**`, `*italic*`, `` `code` ``, ` ```code blocks``` `, `~~strikethrough~~`, lists, newlines) to the HTML that Teams expects for `RichText/Html` messages. The converter is used by `sendMessage()` and `editMessage()` in `chatsvc-api.ts`. When messages contain @mentions or links, `parseContentWithMentionsAndLinks()` applies the same conversion to text segments between inline elements.
+11. **Markdown to Teams HTML**: Outgoing messages support markdown formatting via `markdownToTeamsHtml()` in `utils/parsers.ts`. This converts markdown (`**bold**`, `*italic*`, `` `code` ``, ` ```code blocks``` `, `~~strikethrough~~`, lists, newlines) to the HTML that Teams expects for `RichText/Html` messages. The converter is used by `sendMessage()` and `editMessage()` in `chatsvc-api.ts`. When messages contain @mentions or links, `parseContentWithMentionsAndLinks()` applies the same conversion to text segments between inline elements.
 
 ## How It Works
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,6 +7,11 @@
 | P3 | Get person details | Detailed profile info (working hours, OOO status) | Easy | Delve API |
 | P3 | Get message by URL | Fetch a specific message from a Teams link with surrounding context | Medium | Parse URL to extract conversation/message IDs, return target message plus N messages before/after |
 | P4 | Meeting attendees | Filter meetings by attendee (not just organiser) | Medium | Need to research attendee list in calendar API response |
+| P3 | **Reduce chatsvc-api boilerplate** | **Extract `requireMessageAuthWithConfig()` helper returning `{ auth, region, baseUrl }`** | **Easy** | **Eliminates 4-line auth+config pattern repeated 16× in `chatsvc-api.ts`. See `2026-02-12-full-code-review.md` D3** |
+| P3 | **Substrate error response wrapper** | **Extract helper that clears token cache on `AUTH_EXPIRED` after Substrate/files API calls** | **Easy** | **Same `if (!response.ok) { if (AUTH_EXPIRED) clearTokenCache(); return response; }` pattern repeated 5× across `substrate-api.ts` and `files-api.ts`. See review D4** |
+| P4 | Split chatsvc-api.ts | Break 1,600+ line file into sub-modules (messaging, activity, reactions, virtual-conversations) | Medium | Largest file in codebase. See review R2. Would also split `message-tools.ts` (1,079 lines, R3) along same boundaries |
+| P4 | Typed API response interfaces | Define lightweight interfaces for common raw API response shapes | Easy | Reduces `as Record<string, unknown>` casts. Most impactful in `getSharedFiles` (20+ casts) and `getActivityFeed`. See review R4 |
+| P4 | Additional test coverage | Add tests for `httpRequest` retry/timeout logic (T8), tool registry `invokeTool` with Zod validation (T7) | Medium | Requires mocking `fetch`. Current coverage is strong for pure functions but weak for integration |
 
 ## Browserless Token Refresh
 

--- a/docs/2026-02-12-full-code-review.md
+++ b/docs/2026-02-12-full-code-review.md
@@ -1,0 +1,290 @@
+# Clean Code Review: msteams-mcp
+
+**Date**: 2026-02-12
+**Branch**: `refactor/clean-code-review`
+**Scope**: ~7,500 lines across 30 source files
+**Tests**: 117 → 179 passing
+
+---
+
+## Phase 1: Scope
+
+MCP server enabling AI assistants to interact with Microsoft Teams via direct API calls (Substrate, chatsvc, CSA) with browser-based authentication.
+
+### Directory Structure
+
+```
+src/
+├── index.ts              # Entry point
+├── server.ts             # MCP server (TeamsServer class)
+├── constants.ts          # Shared constants
+├── tools/                # Tool handlers (6 files, ~3,200 lines)
+├── api/                  # API clients (7 files, ~3,000 lines)
+├── auth/                 # Authentication (5 files, ~1,300 lines)
+├── browser/              # Playwright login (2 files, ~620 lines)
+├── utils/                # Parsers, HTTP, config (4 files, ~1,600 lines)
+├── types/                # Interfaces (4 files, ~270 lines)
+└── __fixtures__/         # Test data (1 file)
+```
+
+---
+
+## Phase 2: Readability & Clarity
+
+### Strengths
+
+- **Excellent module organisation** — clear separation into `api/`, `auth/`, `browser/`, `tools/`, `types/`, `utils/` with barrel exports
+- **Consistent naming** — functions, types, and files follow clear conventions (`extractX`, `parseX`, `requireX`, `getX`)
+- **Result types** — `Result<T, McpError>` forces explicit error handling everywhere
+- **Error taxonomy** — machine-readable `ErrorCode` enum with LLM-friendly `suggestions` arrays
+- **Section dividers** — consistent `// ───────` separators in larger files aid navigation
+- **JSDoc** — thorough on public APIs with `@param`, `@returns`, `@example`, `@see` where appropriate
+
+### Issues
+
+#### R1. Reaction functions used inline headers instead of shared helper ✅ FIXED
+
+`addReaction` and `removeReaction` in `chatsvc-api.ts` manually constructed headers identical to `getSkypeAuthHeaders()`. Every other chatsvc function used the shared helpers.
+
+**Fix**: Unified into `setReaction` helper using `getSkypeAuthHeaders()`.
+
+#### R2. `chatsvc-api.ts` is 1,680 lines — the largest file by far
+
+Handles messaging, threads, saved messages, followed threads, chat creation, consumption horizons, activity feed, and reactions. Consider splitting into sub-modules (e.g., `chatsvc-messaging.ts`, `chatsvc-activity.ts`, `chatsvc-reactions.ts`).
+
+**Status**: Deferred — added to ROADMAP.md as P4.
+
+#### R3. `message-tools.ts` is 1,079 lines
+
+Contains 18 tool definitions with handlers. Could be split along the same lines as the API layer.
+
+**Status**: Deferred — grouped with R2 in ROADMAP.md.
+
+#### R4. Inconsistent `as` casting style in API response parsing
+
+Throughout `chatsvc-api.ts` and `files-api.ts`, raw API responses are parsed with extensive `as Record<string, unknown>` casts. Some functions (e.g., `getSharedFiles`) have 20+ casts. Consider defining lightweight response interfaces for common shapes.
+
+**Status**: Deferred — added to ROADMAP.md as P4.
+
+#### R5. `index.ts` entry point comment was stale ✅ FIXED
+
+Said "search Microsoft Teams messages using browser automation" — the server does far more and uses direct API calls.
+
+**Fix**: Updated to describe the full scope.
+
+---
+
+## Phase 3: Duplication
+
+#### D1. `getApiConfig()` was defined identically in two files ✅ FIXED
+
+Identical private function in `chatsvc-api.ts` (line 46) and `csa-api.ts` (line 23):
+
+```typescript
+function getApiConfig() {
+  return { region: getRegion(), baseUrl: getTeamsBaseUrl() };
+}
+```
+
+**Fix**: Exported from `auth-guards.ts` with `ApiConfig` interface. Both files now import it.
+
+#### D2. `addReaction` / `removeReaction` were ~90% identical ✅ FIXED
+
+Only differences: HTTP method (`PUT` vs `DELETE`) and body (`{ key, value: Date.now() }` vs `{ key }`).
+
+**Fix**: Extracted `setReaction(conversationId, messageId, emojiKey, method)` private helper.
+
+#### D3. Auth-guard + `getApiConfig` boilerplate repeated in every API function
+
+Every function in `chatsvc-api.ts` (16 times) follows this pattern:
+
+```typescript
+const authResult = requireMessageAuth();
+if (!authResult.ok) return authResult;
+const auth = authResult.value;
+const { region, baseUrl } = getApiConfig();
+```
+
+4 lines × 16 functions = 64 lines of pure boilerplate. A helper like `requireMessageAuthWithConfig()` returning `{ auth, region, baseUrl }` would eliminate this.
+
+**Status**: Deferred — added to ROADMAP.md as P3. Too many call sites to change safely in a single review PR.
+
+#### D4. Substrate token cache-clearing on `AUTH_EXPIRED` repeated 5 times
+
+In `substrate-api.ts` and `files-api.ts`:
+
+```typescript
+if (!response.ok) {
+  if (response.error.code === ErrorCode.AUTH_EXPIRED) {
+    clearTokenCache();
+  }
+  return response;
+}
+```
+
+**Status**: Deferred — added to ROADMAP.md as P3. Could be a wrapper or middleware in `http.ts`.
+
+#### D5. `getSavedMessages` and `getFollowedThreads` were structurally identical ✅ FIXED
+
+Both fetched from a virtual conversation, parsed with `parseVirtualConversationMessage`, and returned the same shape. Differed only in conversation ID and regex pattern.
+
+**Fix**: Extracted `fetchVirtualConversation(virtualConversationId, referencePattern, options)` shared helper. Each public function is now a thin wrapper that maps `sourceReferenceId` to the appropriate field name (`sourceMessageId` vs `sourcePostId`).
+
+---
+
+## Phase 4: Simplification
+
+#### S1. `extractObjectId` had repetitive branch structure ✅ FIXED
+
+The GUID-test-then-base64-decode logic was repeated 4 times for different prefix formats.
+
+**Fix**: Extracted `resolveIdPart(idPart)` closure:
+
+```typescript
+const resolveIdPart = (idPart: string): string | null => {
+  if (guidPattern.test(idPart)) return idPart.toLowerCase();
+  if (isLikelyBase64Guid(idPart)) return decodeBase64Guid(idPart);
+  return null;
+};
+```
+
+Each branch now calls `resolveIdPart(identifier.substring(N))` — function went from 56 lines to 30.
+
+#### S2. `Promise.resolve(requireMessageAuth())` in `files-api.ts` ✅ FIXED
+
+`requireMessageAuth()` is synchronous, so wrapping it in `Promise.resolve()` just to use `Promise.all` was unnecessary.
+
+**Fix**: Call it directly first, then `await` the async token check.
+
+#### S3. `getSubstrateTokenStatus` duplicates logic from `calculateTokenStatus`
+
+In `token-extractor.ts`, `getSubstrateTokenStatus()` (line 184) and `getMessageAuthStatus()` (line 546) manually compute `expiresAt` and `minutesRemaining` — the same calculation that `calculateTokenStatus()` in `parsers.ts` already provides.
+
+**Status**: Not fixed — low impact, would require changing the return type signatures.
+
+#### S4. `hasMarkdownFormatting` checks for newlines
+
+```typescript
+if (/\n/.test(text)) return true;
+```
+
+Any message with a newline is treated as "has markdown formatting." Technically correct for the conversion pipeline, but the function name is slightly misleading — it's really `needsHtmlConversion`.
+
+**Status**: Not fixed — renaming would touch callers and the function works correctly as-is.
+
+---
+
+## Phase 5: Documentation Accuracy
+
+#### Doc1. `index.ts` module comment was outdated ✅ FIXED
+
+Updated from "search Microsoft Teams messages using browser automation" to describe the full scope.
+
+#### Doc2. `server.ts` module comment was outdated ✅ FIXED
+
+Updated from "Teams search" to "Microsoft Teams" with full capability list.
+
+#### Doc3. `AGENTS.md` referenced non-existent `test/` directory ✅ FIXED
+
+Removed from the directory tree.
+
+#### Doc4. `createGroupChat` JSDoc had stale `@param region` ✅ FIXED
+
+The function no longer accepts a `region` parameter — removed from JSDoc.
+
+#### Doc5. Unused interfaces in `types/teams.ts` ✅ FIXED
+
+Removed 7 interfaces only referenced in their own definition file:
+- `TeamsMessage`
+- `TeamsReaction`
+- `InterceptedRequest`
+- `InterceptedResponse`
+- `SearchApiEndpoint`
+- `SearchPaginationOptions`
+- `TeamsSearchResultsWithPagination`
+
+#### Doc6. `AGENTS.md` had duplicate item 7 ✅ FIXED
+
+Two items numbered "7" in the Implementation Patterns list. Renumbered 7–10 → 7–11.
+
+---
+
+## Phase 6: Test Coverage
+
+### Existing coverage (before review)
+
+`parsers.test.ts` — **117 tests** covering: `stripHtml`, `extractLinks`, `buildMessageLink`, `getConversationType`, `extractMessageTimestamp`, `decodeBase64Guid`, `parsePersonSuggestion`, `parseV2Result`, `parseJwtProfile`, `calculateTokenStatus`, `parseSearchResults`, `parsePeopleResults`, `extractObjectId`, `buildOneOnOneConversationId`, `extractActivityTimestamp`, `markdownToTeamsHtml`, `formatTranscriptText`.
+
+### New tests added (+62) ✅
+
+#### `parsers.test.ts` (+30 tests)
+
+- **`parseChannelSuggestion`** (3 tests): complete suggestion, missing fields → null, default channelType
+- **`parseChannelResults`** (3 tests): groups structure, undefined input, non-channel entities skipped
+- **`parseTeamsList`** (4 tests): teams with channels, channelType mapping (0→Standard, 1→Private, 2→Shared), undefined/missing data, missing required fields
+- **`filterChannelsByName`** (3 tests): case-insensitive partial match, cross-team results, no match
+- **`parseVirtualConversationMessage`** (7 tests): saved message parsing, followed thread parsing, Control messages → null, missing id → null, missing timestamp → null, missing secondaryReferenceId, link building with context, HTML link extraction
+- **`hasMarkdownFormatting`** (10 tests): bold, italic, strikethrough, inline code, code blocks, unordered lists, ordered lists, newlines, plain text → false
+
+#### `errors.test.ts` (22 tests) — NEW FILE
+
+- **`createError`** (8 tests): default suggestions per code, retryable defaults (RATE_LIMITED/NETWORK_ERROR/TIMEOUT/API_ERROR → true, AUTH_REQUIRED/INVALID_INPUT → false), custom overrides, retryAfterMs
+- **`classifyHttpError`** (10 tests): 401→AUTH_EXPIRED, 403→AUTH_REQUIRED, 404→NOT_FOUND, 429→RATE_LIMITED, 400/422→INVALID_INPUT, 500+→API_ERROR, timeout/network messages, unknown status
+- **`extractRetryAfter`** (3 tests): numeric seconds→ms conversion, missing header→undefined, HTTP date format
+
+#### `crypto.test.ts` (10 tests) — NEW FILE
+
+- **encrypt/decrypt round-trip** (5 tests): simple string, JSON data, empty string, unicode content, unique IV per encryption
+- **`isEncrypted`** (3 tests): encrypted data → true, partial/null/string → false, manual object with all fields → true
+- **decrypt error handling** (2 tests): tampered ciphertext → throw, tampered auth tag → throw
+
+### Remaining gaps (not addressed)
+
+- **T7**: No integration/tool-level tests — `invokeTool` with Zod validation in `registry.ts`
+- **T8**: No tests for `httpRequest` retry/timeout logic — requires mocking `fetch`
+
+Both added to ROADMAP.md as P4.
+
+---
+
+## Phase 7: Summary
+
+### Overall Assessment: **Good** 🟢
+
+Well-structured, well-documented codebase with strong architectural decisions. The code is clearly written by someone who understands both the problem domain and clean code principles.
+
+### What Was Fixed (this PR)
+
+| # | Category | Item | Lines saved |
+|---|----------|------|-------------|
+| D1 | Duplication | Shared `getApiConfig()` | ~14 |
+| D2 | Duplication | Unified reaction functions | ~50 |
+| D5 | Duplication | Unified virtual conversation fetcher | ~60 |
+| R1 | Readability | Reaction headers use shared helper | — |
+| S1 | Simplification | `resolveIdPart` in `extractObjectId` | ~26 |
+| S2 | Simplification | Removed `Promise.resolve` wrapper | ~4 |
+| Doc1-6 | Documentation | Fixed stale comments, numbering, unused types | ~55 |
+| T1-T6 | Tests | +62 new tests across 3 files | +450 |
+
+**Net**: +706 / -256 lines (mostly tests), 179 tests passing
+
+### What's Deferred (in ROADMAP.md)
+
+| # | Priority | Item | Reason |
+|---|----------|------|--------|
+| D3 | P3 | Auth+config boilerplate helper | 16 call sites — too invasive for review PR |
+| D4 | P3 | Substrate error response wrapper | 5 call sites across 2 files |
+| R2/R3 | P4 | Split large files | Structural change, needs careful planning |
+| R4 | P4 | Typed API response interfaces | Low urgency, incremental improvement |
+| T7/T8 | P4 | Integration & HTTP retry tests | Requires fetch mocking infrastructure |
+
+### What's Done Well (no changes needed)
+
+- **Architecture** — Clean separation of concerns, barrel exports, tool registry pattern
+- **Error handling** — Consistent `Result<T>` types with machine-readable error codes
+- **Security** — AES-256-GCM encryption at rest, restrictive file permissions, no hardcoded secrets
+- **Testing** — Thorough pure-function tests with realistic fixtures
+- **Documentation** — AGENTS.md is an excellent onboarding document; JSDoc is thorough on public APIs
+- **Constants** — No magic numbers; all thresholds centralised in `constants.ts`
+- **Auth flow** — Persistent browser profile with headless-first strategy is elegant
+- **Region support** — Dynamic config extraction supports commercial, GCC, GCC-High, DoD environments

--- a/src/api/csa-api.ts
+++ b/src/api/csa-api.ts
@@ -9,7 +9,7 @@ import { httpRequest } from '../utils/http.js';
 import { CSA_API, getCsaHeaders } from '../utils/api-config.js';
 import { ErrorCode, createError } from '../types/errors.js';
 import { type Result, ok, err } from '../types/result.js';
-import { requireCsaAuth, getRegion, getTeamsBaseUrl } from '../utils/auth-guards.js';
+import { requireCsaAuth, getApiConfig } from '../utils/auth-guards.js';
 import {
   getConversationProperties,
   extractParticipantNames,
@@ -18,14 +18,6 @@ import {
   parseTeamsList,
   type TeamWithChannels,
 } from '../utils/parsers.js';
-
-/** Gets region and base URL together for API calls. */
-function getApiConfig() {
-  return {
-    region: getRegion(),
-    baseUrl: getTeamsBaseUrl(),
-  };
-}
 
 /** A favourite/pinned conversation item. */
 export interface FavoriteItem {

--- a/src/api/files-api.ts
+++ b/src/api/files-api.ts
@@ -72,16 +72,13 @@ export async function getSharedFiles(
   options: { pageSize?: number; skipToken?: string } = {}
 ): Promise<Result<GetSharedFilesResult>> {
   // Need both Substrate token (for the API) and message auth (for user MRI)
-  const [tokenResult, authResult] = await Promise.all([
-    requireSubstrateTokenAsync(),
-    Promise.resolve(requireMessageAuth()),
-  ]);
-
-  if (!tokenResult.ok) return tokenResult;
+  const authResult = requireMessageAuth();
   if (!authResult.ok) return authResult;
-
-  const token = tokenResult.value;
   const auth = authResult.value;
+
+  const tokenResult = await requireSubstrateTokenAsync();
+  if (!tokenResult.ok) return tokenResult;
+  const token = tokenResult.value;
 
   // Extract user's object ID from their MRI
   const userId = extractObjectId(auth.userMri);

--- a/src/auth/crypto.test.ts
+++ b/src/auth/crypto.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for encryption utilities.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { encrypt, decrypt, isEncrypted, type EncryptedData } from './crypto.js';
+
+describe('encrypt/decrypt round-trip', () => {
+  it('encrypts and decrypts a simple string', () => {
+    const plaintext = 'hello world';
+    const encrypted = encrypt(plaintext);
+    const decrypted = decrypt(encrypted);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it('encrypts and decrypts JSON data', () => {
+    const data = JSON.stringify({ token: 'abc123', expiry: 1705850000 });
+    const encrypted = encrypt(data);
+    const decrypted = decrypt(encrypted);
+    expect(decrypted).toBe(data);
+  });
+
+  it('encrypts and decrypts empty string', () => {
+    const encrypted = encrypt('');
+    const decrypted = decrypt(encrypted);
+    expect(decrypted).toBe('');
+  });
+
+  it('encrypts and decrypts unicode content', () => {
+    const text = 'Hello 🌍 — "quotes" & <tags>';
+    const encrypted = encrypt(text);
+    const decrypted = decrypt(encrypted);
+    expect(decrypted).toBe(text);
+  });
+
+  it('produces different ciphertext for same plaintext (unique IV)', () => {
+    const plaintext = 'same input';
+    const encrypted1 = encrypt(plaintext);
+    const encrypted2 = encrypt(plaintext);
+    // IVs should differ, so ciphertext differs
+    expect(encrypted1.iv).not.toBe(encrypted2.iv);
+    expect(encrypted1.content).not.toBe(encrypted2.content);
+  });
+});
+
+describe('isEncrypted', () => {
+  it('returns true for encrypted data structure', () => {
+    const encrypted = encrypt('test');
+    expect(isEncrypted(encrypted)).toBe(true);
+  });
+
+  it('returns false for plain objects', () => {
+    expect(isEncrypted({})).toBe(false);
+    expect(isEncrypted({ content: 'abc' })).toBe(false);
+    expect(isEncrypted({ iv: 'abc' })).toBe(false);
+    expect(isEncrypted(null)).toBe(false);
+    expect(isEncrypted(undefined)).toBe(false);
+    expect(isEncrypted('string')).toBe(false);
+  });
+
+  it('returns true for object with all required fields', () => {
+    expect(isEncrypted({ content: 'x', iv: 'y', tag: 'z', version: 1 })).toBe(true);
+  });
+});
+
+describe('decrypt error handling', () => {
+  it('throws on tampered ciphertext', () => {
+    const encrypted = encrypt('secret');
+    const tampered: EncryptedData = {
+      ...encrypted,
+      content: encrypted.content.slice(0, -2) + 'xx',
+    };
+    expect(() => decrypt(tampered)).toThrow();
+  });
+
+  it('throws on tampered auth tag', () => {
+    const encrypted = encrypt('secret');
+    const tampered: EncryptedData = {
+      ...encrypted,
+      tag: 'a'.repeat(encrypted.tag.length),
+    };
+    expect(() => decrypt(tampered)).toThrow();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,10 @@
 /**
  * Teams MCP Server entry point.
  * 
- * This MCP server enables AI assistants to search Microsoft Teams
- * messages using browser automation.
+ * This MCP server enables AI assistants to interact with Microsoft Teams
+ * via direct API calls — searching messages, sending replies, managing
+ * favourites, calendar, files, and more. The browser is only used for
+ * initial authentication.
  */
 
 import { runServer } from './server.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 /**
- * MCP Server implementation for Teams search.
- * Exposes tools and resources for interacting with Microsoft Teams.
+ * MCP Server implementation for Microsoft Teams.
+ * Exposes tools and resources for searching, messaging, calendar, files, and more.
  */
 
 import { createRequire } from 'module';

--- a/src/types/errors.test.ts
+++ b/src/types/errors.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for error taxonomy functions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ErrorCode,
+  createError,
+  classifyHttpError,
+  extractRetryAfter,
+} from './errors.js';
+
+describe('createError', () => {
+  it('creates error with defaults for AUTH_REQUIRED', () => {
+    const error = createError(ErrorCode.AUTH_REQUIRED, 'Not authenticated');
+    expect(error.code).toBe(ErrorCode.AUTH_REQUIRED);
+    expect(error.message).toBe('Not authenticated');
+    expect(error.retryable).toBe(false);
+    expect(error.suggestions).toContain('Call teams_login to authenticate');
+  });
+
+  it('creates retryable error for RATE_LIMITED by default', () => {
+    const error = createError(ErrorCode.RATE_LIMITED, 'Too many requests');
+    expect(error.retryable).toBe(true);
+  });
+
+  it('creates retryable error for NETWORK_ERROR by default', () => {
+    const error = createError(ErrorCode.NETWORK_ERROR, 'Connection failed');
+    expect(error.retryable).toBe(true);
+  });
+
+  it('creates retryable error for TIMEOUT by default', () => {
+    const error = createError(ErrorCode.TIMEOUT, 'Request timed out');
+    expect(error.retryable).toBe(true);
+  });
+
+  it('creates retryable error for API_ERROR by default', () => {
+    const error = createError(ErrorCode.API_ERROR, 'Server error');
+    expect(error.retryable).toBe(true);
+  });
+
+  it('creates non-retryable error for INVALID_INPUT by default', () => {
+    const error = createError(ErrorCode.INVALID_INPUT, 'Bad input');
+    expect(error.retryable).toBe(false);
+  });
+
+  it('allows overriding retryable flag', () => {
+    const error = createError(ErrorCode.AUTH_REQUIRED, 'Auth needed', { retryable: true });
+    expect(error.retryable).toBe(true);
+  });
+
+  it('allows custom suggestions', () => {
+    const error = createError(ErrorCode.UNKNOWN, 'Something broke', {
+      suggestions: ['Try again', 'Contact support'],
+    });
+    expect(error.suggestions).toEqual(['Try again', 'Contact support']);
+  });
+
+  it('includes retryAfterMs when provided', () => {
+    const error = createError(ErrorCode.RATE_LIMITED, 'Slow down', {
+      retryAfterMs: 5000,
+    });
+    expect(error.retryAfterMs).toBe(5000);
+  });
+});
+
+describe('classifyHttpError', () => {
+  it('classifies 401 as AUTH_EXPIRED', () => {
+    expect(classifyHttpError(401)).toBe(ErrorCode.AUTH_EXPIRED);
+  });
+
+  it('classifies 403 as AUTH_REQUIRED', () => {
+    expect(classifyHttpError(403)).toBe(ErrorCode.AUTH_REQUIRED);
+  });
+
+  it('classifies 404 as NOT_FOUND', () => {
+    expect(classifyHttpError(404)).toBe(ErrorCode.NOT_FOUND);
+  });
+
+  it('classifies 429 as RATE_LIMITED', () => {
+    expect(classifyHttpError(429)).toBe(ErrorCode.RATE_LIMITED);
+  });
+
+  it('classifies 400 as INVALID_INPUT', () => {
+    expect(classifyHttpError(400)).toBe(ErrorCode.INVALID_INPUT);
+  });
+
+  it('classifies 422 as INVALID_INPUT', () => {
+    expect(classifyHttpError(422)).toBe(ErrorCode.INVALID_INPUT);
+  });
+
+  it('classifies 500+ as API_ERROR', () => {
+    expect(classifyHttpError(500)).toBe(ErrorCode.API_ERROR);
+    expect(classifyHttpError(502)).toBe(ErrorCode.API_ERROR);
+    expect(classifyHttpError(503)).toBe(ErrorCode.API_ERROR);
+  });
+
+  it('classifies timeout message as TIMEOUT', () => {
+    expect(classifyHttpError(0, 'request timeout')).toBe(ErrorCode.TIMEOUT);
+  });
+
+  it('classifies network message as NETWORK_ERROR', () => {
+    expect(classifyHttpError(0, 'network error')).toBe(ErrorCode.NETWORK_ERROR);
+    expect(classifyHttpError(0, 'ECONNRESET')).toBe(ErrorCode.NETWORK_ERROR);
+  });
+
+  it('classifies unknown status as UNKNOWN', () => {
+    expect(classifyHttpError(418)).toBe(ErrorCode.UNKNOWN);
+  });
+});
+
+describe('extractRetryAfter', () => {
+  it('extracts numeric Retry-After in seconds and converts to ms', () => {
+    const headers = new Headers({ 'Retry-After': '30' });
+    expect(extractRetryAfter(headers)).toBe(30000);
+  });
+
+  it('returns undefined when header is missing', () => {
+    const headers = new Headers();
+    expect(extractRetryAfter(headers)).toBeUndefined();
+  });
+
+  it('handles HTTP date format', () => {
+    // Use a future date to get a positive value
+    const futureDate = new Date(Date.now() + 60000).toUTCString();
+    const headers = new Headers({ 'Retry-After': futureDate });
+    const result = extractRetryAfter(headers);
+    expect(result).toBeDefined();
+    expect(result!).toBeGreaterThan(0);
+    expect(result!).toBeLessThanOrEqual(60000);
+  });
+});

--- a/src/types/teams.ts
+++ b/src/types/teams.ts
@@ -24,59 +24,6 @@ export interface TeamsSearchResult {
   links?: ExtractedLink[];
 }
 
-export interface TeamsMessage {
-  id: string;
-  content: string;
-  sender: string;
-  timestamp: string;
-  channelName?: string;
-  teamName?: string;
-  replyCount?: number;
-  reactions?: TeamsReaction[];
-}
-
-export interface TeamsReaction {
-  type: string;
-  count: number;
-}
-
-export interface InterceptedRequest {
-  url: string;
-  method: string;
-  headers: Record<string, string>;
-  postData?: string;
-  timestamp: Date;
-}
-
-export interface InterceptedResponse {
-  url: string;
-  status: number;
-  headers: Record<string, string>;
-  body?: string;
-  timestamp: Date;
-}
-
-// Note: SessionState is defined in auth/session-store.ts (the authoritative source)
-// Import from there if needed: import { type SessionState } from '../auth/session-store.js';
-
-export interface SearchApiEndpoint {
-  url: string;
-  method: string;
-  description: string;
-  requestFormat?: unknown;
-  responseFormat?: unknown;
-}
-
-/** Pagination options for search requests. */
-export interface SearchPaginationOptions {
-  /** Starting offset (0-based). Default: 0 */
-  from?: number;
-  /** Page size. Default: 25 */
-  size?: number;
-  /** Maximum total results to fetch across all pages. */
-  maxResults?: number;
-}
-
 /** Pagination metadata returned with search results. */
 export interface SearchPaginationResult {
   /** Number of results returned in this response. */
@@ -91,8 +38,4 @@ export interface SearchPaginationResult {
   hasMore: boolean;
 }
 
-/** Search results with pagination metadata. */
-export interface TeamsSearchResultsWithPagination {
-  results: TeamsSearchResult[];
-  pagination: SearchPaginationResult;
-}
+

--- a/src/utils/auth-guards.ts
+++ b/src/utils/auth-guards.ts
@@ -195,6 +195,25 @@ export function getRegionConfig(): RegionConfig | null {
   return cachedRegionConfig;
 }
 
+/** API config with region and base URL for constructing API endpoints. */
+export interface ApiConfig {
+  region: string;
+  baseUrl: string;
+}
+
+/**
+ * Gets region and base URL together for API calls.
+ * 
+ * Shared helper used by all API modules to avoid duplicating
+ * the getRegion() + getTeamsBaseUrl() pattern.
+ */
+export function getApiConfig(): ApiConfig {
+  return {
+    region: getRegion(),
+    baseUrl: getTeamsBaseUrl(),
+  };
+}
+
 /**
  * Clears the cached region config and tenant ID.
  * Call this after login/logout to pick up new session.


### PR DESCRIPTION
## Clean Code Review

Full review saved in `docs/2026-02-12-full-code-review.md`.

### Changes

**Duplication fixes**
- Extract shared `getApiConfig()` to `auth-guards.ts` (was duplicated in `chatsvc-api.ts` and `csa-api.ts`)
- Unify `addReaction`/`removeReaction` into shared `setReaction` helper, fix headers to use `getSkypeAuthHeaders()`
- Unify `getSavedMessages`/`getFollowedThreads` into shared `fetchVirtualConversation` helper

**Simplifications**
- Extract `resolveIdPart` helper in `extractObjectId` (eliminates 4× repeated GUID resolution logic)
- Remove unnecessary `Promise.resolve()` wrapper in `files-api.ts`

**Documentation**
- Fix stale comments in `index.ts`, `server.ts`, `createGroupChat` JSDoc
- Fix duplicate numbering and remove non-existent `test/` dir in `AGENTS.md`
- Remove 7 unused interfaces from `types/teams.ts`
- Add 5 deferred tasks to `ROADMAP.md` with cross-references

**Tests: 117 → 179 passing (+62)**
- `parsers.test.ts`: channel parsers, `parseVirtualConversationMessage`, `hasMarkdownFormatting`
- `errors.test.ts` (new): `createError`, `classifyHttpError`, `extractRetryAfter`
- `crypto.test.ts` (new): encrypt/decrypt round-trip, `isEncrypted`, tamper detection

### Deferred (added to ROADMAP.md)
- D3: Auth+config boilerplate helper (16 call sites)
- D4: Substrate error response wrapper (5 call sites)
- R2/R3: Split large files (`chatsvc-api.ts`, `message-tools.ts`)
- R4: Typed API response interfaces
- T7/T8: Integration & HTTP retry tests