### PR TITLE
feat: add email search tool (teams_search_email)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ Different Teams APIs use different authentication mechanisms:
 | API | Auth Method | Module | Helper Function |
 |-----|-------------|--------|-----------------|
 | **Search** (Substrate v2/query) | JWT Bearer token from MSAL | `auth/token-extractor` | `getValidSubstrateToken()` |
+| **Email Search** (Substrate v2/query) | Same JWT as Search (contentSources: Exchange) | `auth/token-extractor` | `getValidSubstrateToken()` |
 | **People/Suggestions** (Substrate v1/suggestions) | Same JWT + `cvid`/`logicalId` fields | `auth/token-extractor` | `getValidSubstrateToken()` |
 | **Messaging** (chatsvc) | `skypetoken_asm` cookie | `auth/token-extractor` | `extractMessageAuth()` |
 | **Favorites** (csa/conversationFolders) | CSA token from MSAL + `skypetoken_asm` | `auth/token-extractor` | `extractCsaToken()` + `extractMessageAuth()` |
@@ -179,7 +180,8 @@ Session state and token cache files are protected by:
 
 | Tool | Purpose |
 |------|---------|
-| `teams_search` | Search messages with query operators, supports pagination |
+| `teams_search` | Search Teams messages with query operators, supports pagination |
+| `teams_search_email` | Search emails in user's mailbox (same Substrate token as Teams search) |
 | `teams_send_message` | Send a message to a Teams conversation (use `replyToMessageId` for thread replies) |
 | `teams_get_me` | Get current user profile (email, name, ID) |
 | `teams_get_frequent_contacts` | Get frequently contacted people (for name resolution) |
@@ -298,6 +300,7 @@ npm run typecheck     # TypeScript type checking only
 - JWT profile extraction (`parseJwtProfile`)
 - Token expiry calculations (`calculateTokenStatus`)
 - People results parsing (`parsePeopleResults`)
+- Email result parsing (`parseEmailResult`, `parseEmailSearchResults`)
 - Base64 GUID decoding (`decodeBase64Guid`)
 - User ID extraction from various formats (`extractObjectId`)
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ The server uses your system's Chrome (macOS/Linux) or Edge (Windows) for authent
 
 | Tool | Description |
 |------|-------------|
-| `teams_search` | Search messages with operators (`from:`, `sent:`, `in:`, `hasattachment:`, etc.) |
+| `teams_search` | Search Teams messages with operators (`from:`, `sent:`, `in:`, `hasattachment:`, etc.) |
+| `teams_search_email` | Search emails in your mailbox (same auth as Teams — no extra login) |
 | `teams_get_thread` | Get messages from a conversation/thread |
 | `teams_find_channel` | Find channels by name (your teams + org-wide discovery) |
 | `teams_get_activity` | Get activity feed (mentions, reactions, replies, notifications) |
@@ -147,15 +148,17 @@ Returns both files (name, extension, URL, size) and links (URL, title), along wi
 
 ### Search Operators
 
-The search supports Teams' native operators:
+Both `teams_search` (Teams messages) and `teams_search_email` (emails) support native operators:
 
 ```
-from:sarah@company.com     # Messages from person
-sent:2026-01-20            # Messages from specific date
-sent:>=2026-01-15          # Messages since date
-in:project-alpha           # Messages in channel
+from:sarah@company.com     # Messages/emails from person
+sent:2026-01-20            # From specific date
+sent:>=2026-01-15          # Since date
+in:project-alpha           # Messages in channel (Teams only)
+subject:"budget"           # By subject (email)
 "Rob Smith"                # Find @mentions (name in quotes)
-hasattachment:true         # Messages with files
+hasattachment:true         # With files
+is:unread                  # Unread emails (email only)
 NOT from:email@co.com      # Exclude results
 ```
 
@@ -184,6 +187,9 @@ npm run cli -- status
 # Search messages
 npm run cli -- search "meeting notes"
 npm run cli -- search "project" --from 0 --size 50
+
+# Search emails
+npm run cli -- teams_search_email --query "from:sarah@company.com"
 
 # Send messages (default: your own notes/self-chat)
 npm run cli -- send "Hello from Teams MCP!"

--- a/docs/MANUAL-TEST-SCRIPT.md
+++ b/docs/MANUAL-TEST-SCRIPT.md
@@ -18,7 +18,8 @@ This is a test script for verifying all MCP tools work correctly before release.
 ### Search & Discovery
 | Tool | Purpose |
 |------|---------|
-| `teams_search` | Search messages with query operators |
+| `teams_search` | Search Teams messages with query operators |
+| `teams_search_email` | Search emails in your mailbox (same auth as Teams) |
 | `teams_find_channel` | Find channels by name (your teams + org-wide) |
 | `teams_search_people` | Search for people by name or email |
 | `teams_get_frequent_contacts` | Get frequently contacted people (for name resolution) |
@@ -178,6 +179,15 @@ When reading channel messages with `teams_get_thread`:
 3. Use skipToken from response to paginate if there are more files
 ```
 
+### Search emails
+```
+1. teams_search_email query="from:sarah@company.com" → search emails from a person
+2. teams_search_email query="subject:budget sent:>=2026-01-15" → search by subject and date
+3. teams_search_email query="hasattachment:true is:unread" → unread emails with attachments
+```
+Returns: subject, sender, recipients, preview, read status, importance, attachments, and pagination.
+Uses the same Substrate token as Teams search — no additional login required.
+
 ### Get a meeting transcript
 ```
 1. teams_get_meetings startDate="past date" → find the meeting, get threadId
@@ -236,6 +246,9 @@ Quick reactions: `like` (👍), `heart` (❤️), `laugh` (😂), `surprised` (�
 
 ### Meeting transcript
 > "Get the transcript from my last standup meeting and summarise the key decisions."
+
+### Search emails
+> "Search my emails for anything from [person] about [topic] in the last week."
 
 ### People lookup
 > "Find [person name]'s contact details and check if I have any recent conversations with them."

--- a/docs/spikes/graph-api-scopes.md
+++ b/docs/spikes/graph-api-scopes.md
@@ -1,4 +1,6 @@
-# Drop Internal APIs — Move to Graph + Outlook REST
+# [SPIKE] Drop Internal APIs — Move to Graph + Outlook REST
+
+> **Status: Investigation only.** This documents findings from testing Microsoft Graph API scopes. The current architecture still uses Substrate/chatsvc/Skype internal APIs.
 
 Migrate from Substrate/chatsvc/Skype internal APIs to Microsoft Graph + Outlook REST, using `outlook.office.com` SSO (client ID `9199bf20-a13f-4107-85dc-02114787ef48`) which gives `Chat.Read` + `Chat.ReadWrite` on Graph.
 

--- a/docs/spikes/graph-api-scopes.md
+++ b/docs/spikes/graph-api-scopes.md
@@ -1,0 +1,144 @@
+# Drop Internal APIs — Move to Graph + Outlook REST
+
+Migrate from Substrate/chatsvc/Skype internal APIs to Microsoft Graph + Outlook REST, using `outlook.office.com` SSO (client ID `9199bf20-a13f-4107-85dc-02114787ef48`) which gives `Chat.Read` + `Chat.ReadWrite` on Graph.
+
+## SSO Target Comparison (All Live-Tested)
+
+| Graph Scope | Teams (`5e3ce6c0`) | Outlook (`9199bf20`) | M365 Chat (`c0ab8ce9`) | M365 Apps (`4765445b`) |
+|---|---|---|---|---|
+| **Chat.ReadWrite** | ❌ | ✅ | ❌ | ❌ |
+| **Chat.Read** | ❌ | ✅ | ChatReadBasic | ❌ |
+| **ChatMessage.Send** | ✅ | ❌ | ✅ | ❌ |
+| **Calendars** | ReadWrite | ❌ | Read | Read |
+| **Mail** | Read/ReadWrite | ❌ | MailboxSettings | ❌ |
+| **Presence** | ❌ | ❌ | ❌ | Read.All ✅ |
+| **Files** | ReadWrite.All | ReadWrite.All | ReadWrite.All | ReadWrite.All |
+| **People** | Read | Read | Read | Read |
+| **OnlineMeetings** | ❌ | ReadWrite | ❌ | ❌ |
+
+**Winner: Outlook** — only SSO target with `Chat.Read` + `Chat.ReadWrite` on Graph.
+
+Outlook web client ID (`9199bf20-a13f-4107-85dc-02114787ef48`) provides two tokens:
+- **Graph token** — `Chat.Read`, `Chat.ReadWrite`, `Files.ReadWrite.All`, `People.Read`, `OnlineMeetings.ReadWrite`, etc.
+- **Outlook REST token** (`outlook.office.com` audience) — `Calendars.ReadWrite`, `Mail.ReadWrite`, `Contacts.ReadWrite`, `SubstrateSearch-Internal.ReadWrite`, `ChannelMessage.Read.All`, etc.
+
+## Full Feasibility Matrix (All Live-Tested)
+
+### ✅ Can Replace with Graph/Outlook REST (17 tools)
+
+| Current Tool | Current API | Graph/Outlook Replacement | Tested |
+|---|---|---|---|
+| `teams_send_message` | chatsvc | `POST /chats/{id}/messages` | ✅ 201 |
+| `teams_get_thread` | chatsvc | `GET /chats/{id}/messages` | ✅ 200 |
+| `teams_edit_message` | chatsvc | `PATCH /chats/{id}/messages/{id}` | ✅ 204 |
+| `teams_add_reaction` | chatsvc | `POST .../setReaction` | ✅ 204 |
+| `teams_remove_reaction` | chatsvc | `POST .../unsetReaction` | ✅ 204 |
+| `teams_get_chat` | chatsvc | `POST /chats` (oneOnOne) | ✅ 201 |
+| `teams_create_group_chat` | chatsvc | `POST /chats` (group) | ✅ 201 |
+| `teams_search_people` | Substrate | `GET /me/people?$search=` | ✅ 200 |
+| `teams_get_me` | Substrate | `GET /me` | ✅ 200 |
+| `teams_get_frequent_contacts` | Substrate | `GET /me/people` | ✅ 200 |
+| `teams_find_channel` | Substrate | `GET /me/joinedTeams` + `/channels` | ✅ 200 |
+| `teams_get_meetings` | Calendar API | Outlook REST `calendarview` | ✅ 200 |
+| `teams_get_shared_files` | Substrate | `GET /chats/{id}/messages` (attachments) | ✅* |
+| `teams_get_favorites` | CSA | `GET /me/chats?$select=viewpoint` (isPinned) | ✅ 200 |
+| `teams_get_unread` | chatsvc | `GET /me/chats` (viewpoint.lastMessageReadDateTime) | ✅ 200 |
+| `teams_login` | Browser | Same (Outlook SSO instead of Teams) | ✅ |
+| `teams_status` | Internal | Same (check Outlook tokens) | ✅ |
+
+*Files: Graph returns messages with attachments; need to parse differently than Substrate AllFiles.
+
+### ❌ Cannot Replace — Must Keep or Drop (7 tools)
+
+| Current Tool | Current API | Graph Status | Recommendation |
+|---|---|---|---|
+| `teams_search` | Substrate | 403 (chatMessage search needs `ChannelMessage.Read.All` on Graph token — we have it on Outlook token but not Graph) | **Keep Substrate** OR use Outlook REST token for search |
+| `teams_delete_message` | chatsvc | 405 (softDelete not working) | **Keep chatsvc** |
+| `teams_mark_read` | chatsvc | 405 (markChatReadForUser) | **Keep chatsvc** |
+| `teams_get_activity` | chatsvc | No Graph equivalent | **Keep chatsvc** |
+| `teams_get_saved_messages` | chatsvc | No Graph equivalent | **Keep chatsvc** |
+| `teams_get_followed_threads` | chatsvc | No Graph equivalent | **Keep chatsvc** |
+| `teams_save_message` / `unsave` | chatsvc | No Graph equivalent | **Keep chatsvc** |
+| `teams_search_emoji` | Client-side | No Graph equivalent | **Keep client-side** |
+| `teams_get_transcript` | Substrate | Graph needs meeting ID lookup | **Investigate** |
+| `teams_add_favorite` / `remove` | CSA | No pin/unpin API | **Keep CSA** |
+
+### Search: The Biggest Gap
+
+Graph Search (`POST /search/query` with `chatMessage`) returns 403 even with `Chat.Read` — it additionally requires `ChannelMessage.Read.All` **on the Graph token**. Our Outlook Graph token doesn't have that scope (it's on the Outlook REST token instead).
+
+**Options**:
+1. Keep Substrate search (proven, fast) — requires Teams SSO
+2. Use Outlook REST token for Substrate search (has `SubstrateSearch-Internal.ReadWrite`) — **needs testing**
+3. Iterate through chats + filter messages client-side (slow, impractical)
+
+### Transcript: Needs Investigation
+
+Currently uses Substrate `WorkingSetFiles` API. Graph has `GET /me/onlineMeetings/{id}/transcripts` but requires the meeting ID, which needs a lookup from `threadId`. May be feasible but needs work.
+
+## Verdict: Can We Drop Teams SSO Entirely?
+
+**Yes — with one caveat.** The Outlook refresh token can acquire tokens for **all** APIs:
+
+| Token | Outlook Refresh → | Tested |
+|---|---|---|
+| Graph (`Chat.ReadWrite`) | ✅ | Confirmed |
+| Substrate | ✅ acquired | Search returns 400 — **needs investigation** |
+| Skype Spaces | ✅ | Confirmed |
+| skypetoken_asm | ✅ (via Skype exchange) | Confirmed |
+| chatsvcagg | ✅ | Confirmed |
+
+This means **single Outlook SSO** can power everything — Graph for chat ops, chatsvc for the 7 features with no Graph equivalent, and Substrate for search. The only open issue is Substrate search returning 400 with the Outlook-refreshed token (may be a request format or scope difference).
+
+## Architecture: Outlook-Only SSO
+
+```
+Outlook SSO (outlook.office.com) — client ID 9199bf20
+├── Outlook refresh token (captured during SSO via window.msal or token endpoint)
+│   ├── → Graph token (Chat.ReadWrite) → send/list/edit messages, reactions, create chat, people, teams/channels
+│   ├── → Outlook REST token → calendar/meetings, contacts
+│   ├── → Substrate token → search, transcripts (needs 400 fix)
+│   ├── → Skype Spaces token → skypetoken_asm exchange
+│   └── → chatsvcagg token → chatsvc auth
+├── skypetoken_asm (derived from Skype Spaces)
+│   └── → delete, mark read, activity feed, saved msgs, save/unsave, favorites
+└── No Teams SSO needed!
+```
+
+### Migration Strategy
+
+**Phase 1**: Migrate chat tools to Graph (send, list, edit, reactions, create chat) — biggest impact, uses Outlook Graph token directly.
+
+**Phase 2**: Switch SSO from `teams.microsoft.com` to `outlook.office.com`. Capture Outlook refresh token from `window.msal` during login. Use it to refresh all token types.
+
+**Phase 3**: Investigate and fix Substrate search with Outlook-refreshed token. If unfixable, keep Substrate search on Teams token as fallback.
+
+**Phase 4**: Remove Teams SSO dependency (if Phase 3 succeeds).
+
+## Implementation Steps (if proceeding)
+
+### Phase 1: Outlook SSO + Token Management
+1. Switch login target from `teams.microsoft.com` to `outlook.office.com`
+2. Capture Graph + Outlook REST tokens from network requests (not localStorage)
+3. Add Outlook client ID to HTTP token refresh (`Origin: https://outlook.office.com`)
+4. Add `requireOutlookGraphAuth()` and `requireOutlookRestAuth()` guards
+
+### Phase 2: Graph API Module
+5. Create `graph-api.ts` — send, list, edit messages, reactions, create chat
+6. Create `graph-people.ts` — search people, get me, frequent contacts
+7. Create `graph-teams.ts` — list teams, channels, find channel
+
+### Phase 3: Outlook REST Module
+8. Create `outlook-calendar.ts` — meetings, calendar view
+9. Evaluate if Outlook REST token works for Substrate search
+
+### Phase 4: Tool Migration
+10. Migrate all 17 tools to Graph/Outlook REST
+11. Keep chatsvc fallback for the 7 remaining features
+12. Update tool descriptions
+
+### Phase 5: Cleanup
+13. Remove Substrate API calls (if search migrated)
+14. Remove chatsvc calls for migrated tools
+15. Update AGENTS.md, tests
+16. Build + test end-to-end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msteams-mcp",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "MCP server for Microsoft Teams - search messages, send replies, manage favourites",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__fixtures__/api-responses.ts
+++ b/src/__fixtures__/api-responses.ts
@@ -219,6 +219,116 @@ export const sourceWithConvIdMessageId = {
 };
 
 /**
+ * Email search result from Substrate v2 query API.
+ * From: POST https://substrate.office.com/searchservice/api/v2/query
+ * with entityType: 'Message', contentSources: ['Exchange']
+ */
+export const emailSearchResult = {
+  Id: 'AAMkAGE1OWFlZjc0LWYxMjQtNGM1Mi05NzJlLTU0MTU2ZGU1OGM1YQBGAAAAAAEmail',
+  Subject: 'Q3 Budget Review',
+  HitHighlightedSummary: 'Please review the attached <c0>budget</c0> spreadsheet for Q3',
+  Source: {
+    Subject: 'Q3 Budget Review',
+    From: {
+      EmailAddress: {
+        Name: 'Smith, John',
+        Address: 'john.smith@company.com',
+      },
+    },
+    DateTimeReceived: '2026-01-20T14:30:00.000Z',
+    HasAttachments: true,
+    Importance: 'Normal',
+    IsRead: true,
+    DisplayTo: 'Jane Doe; Rob MacDonald',
+    DisplayCc: 'Finance Team',
+    WebLink: 'https://outlook.office.com/mail/id/AAMkAGE1OWFlZjc0',
+    ConversationId: { Id: 'AAQkAGE1OWFlZjc0LWYxMjQtNGM1Mi05NzJl' },
+    Preview: 'Please review the attached budget spreadsheet for Q3',
+  },
+};
+
+/**
+ * Email search result with minimal fields.
+ */
+export const emailSearchResultMinimal = {
+  Id: 'AAMkMinimalEmail',
+  HitHighlightedSummary: 'Quick update on the project status',
+  Source: {
+    Subject: 'Project Update',
+    FromName: 'Jane Doe',
+    FromAddress: 'jane.doe@company.com',
+    DateTimeSent: '2026-01-21T09:00:00.000Z',
+  },
+};
+
+/**
+ * Email search result with structured ToRecipients array.
+ */
+export const emailSearchResultWithRecipients = {
+  Id: 'AAMkRecipientsEmail',
+  Subject: 'Team Meeting Notes',
+  HitHighlightedSummary: 'Here are the notes from today\'s meeting',
+  Source: {
+    Subject: 'Team Meeting Notes',
+    From: 'Alice Johnson',
+    DateTimeReceived: '2026-01-22T16:00:00.000Z',
+    ToRecipients: [
+      { EmailAddress: { Name: 'Bob Wilson', Address: 'bob@company.com' } },
+      { EmailAddress: { Name: 'Carol Davis', Address: 'carol@company.com' } },
+    ],
+    CcRecipients: [
+      { EmailAddress: { Name: 'Dave Brown', Address: 'dave@company.com' } },
+    ],
+    HasAttachments: false,
+    IsRead: false,
+    Importance: 'High',
+  },
+};
+
+/**
+ * Email search result that is a calendar response (should be filtered by default).
+ */
+export const emailSearchResultCalendarResponse = {
+  Id: 'AAMkCalendarResponse',
+  Subject: 'Accepted: Weekly Standup',
+  HitHighlightedSummary: '',
+  Source: {
+    Subject: 'Accepted: Weekly Standup',
+    From: {
+      EmailAddress: {
+        Name: 'Macdonald, Rob',
+        Address: 'rob.macdonald@company.com',
+      },
+    },
+    DateTimeReceived: '2026-02-06T12:50:45.000Z',
+    HasAttachments: false,
+    Importance: 'Normal',
+    IsRead: true,
+  },
+};
+
+/**
+ * Email EntitySets response structure from v2 query.
+ */
+export const emailEntitySetsResponse = {
+  EntitySets: [
+    {
+      ResultSets: [
+        {
+          Total: 142,
+          Results: [
+            emailSearchResult,
+            emailSearchResultMinimal,
+            emailSearchResultWithRecipients,
+            emailSearchResultCalendarResponse,
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+/**
  * Thread message from chatsvc API.
  * From: GET /api/chatsvc/{region}/v1/users/ME/conversations/{id}/messages
  */

--- a/src/api/substrate-api.ts
+++ b/src/api/substrate-api.ts
@@ -10,6 +10,7 @@ import { type Result, ok } from '../types/result.js';
 import { requireSubstrateTokenAsync, getTenantId, getTeamsBaseUrl, handleSubstrateError } from '../utils/auth-guards.js';
 import {
   parseSearchResults,
+  parseEmailSearchResults,
   parsePeopleResults,
   parseChannelResults,
   filterChannelsByName,
@@ -18,12 +19,20 @@ import {
   type LinkContext,
 } from '../utils/parsers.js';
 import { getMyTeamsAndChannels } from './csa-api.js';
-import type { TeamsSearchResult, SearchPaginationResult } from '../types/teams.js';
+import type { TeamsSearchResult, SearchPaginationResult, EmailSearchResult } from '../types/teams.js';
 
 /** Search result with pagination. */
 export interface SearchResult {
   results: TeamsSearchResult[];
   pagination: SearchPaginationResult;
+}
+
+/** Email search result with pagination. */
+export interface EmailSearchResultSet {
+  results: EmailSearchResult[];
+  pagination: SearchPaginationResult;
+  /** Number of calendar responses filtered out (if any). */
+  filteredCount?: number;
 }
 
 /** People search result. */
@@ -115,6 +124,113 @@ export async function searchMessages(
 
   return ok({
     results: limitedResults,
+    pagination: {
+      from,
+      size,
+      returned: limitedResults.length,
+      total,
+      hasMore: total !== undefined
+        ? from + results.length < total
+        : results.length >= size,
+    },
+  });
+}
+
+/**
+ * Searches emails using the Substrate v2 query API.
+ * 
+ * Uses the same Substrate token as Teams message search — the
+ * SubstrateSearch-Internal.ReadWrite scope covers both Teams and Exchange.
+ * The key difference is entityType 'Message' with contentSources ['Exchange'].
+ */
+export async function searchEmails(
+  query: string,
+  options: { from?: number; size?: number; maxResults?: number } = {}
+): Promise<Result<EmailSearchResultSet>> {
+  const tokenResult = await requireSubstrateTokenAsync();
+  if (!tokenResult.ok) {
+    return tokenResult;
+  }
+  const token = tokenResult.value;
+
+  const from = options.from ?? 0;
+  const size = options.size ?? 25;
+
+  const cvid = crypto.randomUUID();
+  const logicalId = crypto.randomUUID();
+
+  const body = {
+    entityRequests: [{
+      entityType: 'Message',
+      contentSources: ['Exchange'],
+      propertySet: 'Optimized',
+      fields: [
+        'Subject',
+        'From',
+        'ToRecipients',
+        'CcRecipients',
+        'DisplayTo',
+        'DisplayCc',
+        'DateTimeReceived',
+        'DateTimeSent',
+        'HasAttachments',
+        'Importance',
+        'IsRead',
+        'Preview',
+        'WebLink',
+        'ConversationId',
+        'FromAddress',
+        'SenderSmtpAddress',
+      ],
+      query: {
+        queryString: query,
+        displayQueryString: query,
+      },
+      from,
+      size,
+      topResultsCount: 5,
+    }],
+    QueryAlterationOptions: {
+      EnableAlteration: true,
+      EnableSuggestion: true,
+      SupportedRecourseDisplayTypes: ['Suggestion'],
+    },
+    cvid,
+    logicalId,
+    scenario: {
+      Dimensions: [
+        { DimensionName: 'QueryType', DimensionValue: 'Mail' },
+        { DimensionName: 'FormFactor', DimensionValue: 'general.web.reactSearch' },
+      ],
+      Name: 'powerbar',
+    },
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  };
+
+  const response = await httpRequest<Record<string, unknown>>(
+    SUBSTRATE_API.search,
+    {
+      method: 'POST',
+      headers: getBearerHeaders(token),
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!response.ok) {
+    return handleSubstrateError(response);
+  }
+
+  const data = response.value.data;
+  const { results, total, filteredCount } = parseEmailSearchResults(
+    data.EntitySets as unknown[] | undefined,
+  );
+
+  const maxResults = options.maxResults ?? size;
+  const limitedResults = results.slice(0, maxResults);
+
+  return ok({
+    results: limitedResults,
+    filteredCount,
     pagination: {
       from,
       size,

--- a/src/api/substrate-api.ts
+++ b/src/api/substrate-api.ts
@@ -221,9 +221,8 @@ export async function searchEmails(
   }
 
   const data = response.value.data;
-  const { results, total, filteredCount } = parseEmailSearchResults(
-    data.EntitySets as unknown[] | undefined,
-  );
+  const entitySets = Array.isArray(data.EntitySets) ? data.EntitySets : undefined;
+  const { results, total, filteredCount } = parseEmailSearchResults(entitySets);
 
   const maxResults = options.maxResults ?? size;
   const limitedResults = results.slice(0, maxResults);
@@ -237,7 +236,7 @@ export async function searchEmails(
       returned: limitedResults.length,
       total,
       hasMore: total !== undefined
-        ? from + results.length < total
+        ? from + size < total
         : results.length >= size,
     },
   });

--- a/src/types/teams.ts
+++ b/src/types/teams.ts
@@ -38,4 +38,39 @@ export interface SearchPaginationResult {
   hasMore: boolean;
 }
 
+/** Classification of an email result. */
+export type EmailType = 'email' | 'calendar-response' | 'notification';
 
+/** An email search result from Substrate. */
+export interface EmailSearchResult {
+  /** Unique ID for this result. */
+  id: string;
+  /** Classification: 'email', 'calendar-response', or 'notification'. */
+  emailType: EmailType;
+  /** Email subject line. */
+  subject: string;
+  /** Sender display name. */
+  sender: string;
+  /** Sender email address. */
+  senderEmail?: string;
+  /** Preview/snippet of the email body (HTML stripped). */
+  preview: string;
+  /** When the email was received (ISO timestamp). */
+  receivedAt?: string;
+  /** Whether the email has attachments. */
+  hasAttachments?: boolean;
+  /** Importance level (Normal, High, Low). */
+  importance?: string;
+  /** Whether the email has been read. */
+  isRead?: boolean;
+  /** To recipients (display names or emails). */
+  toRecipients?: string[];
+  /** CC recipients (display names or emails). */
+  ccRecipients?: string[];
+  /** Web link to open the email in Outlook. */
+  webLink?: string;
+  /** The conversation/thread ID for this email chain. */
+  conversationId?: string;
+  /** Links extracted from email body. */
+  links?: ExtractedLink[];
+}

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -5,7 +5,7 @@
  * They are extracted here for testability - no side effects or external dependencies.
  */
 
-import type { TeamsSearchResult, ExtractedLink } from '../types/teams.js';
+import type { TeamsSearchResult, EmailSearchResult, EmailType, ExtractedLink } from '../types/teams.js';
 import { MIN_CONTENT_LENGTH } from '../constants.js';
 
 // Re-export ExtractedLink so existing imports from parsers.ts continue to work
@@ -495,6 +495,245 @@ export function parseSearchResults(
   }
 
   return { results, total };
+}
+
+/** Subject prefixes that indicate calendar responses (case-insensitive). */
+const CALENDAR_RESPONSE_PREFIXES = [
+  'accepted:',
+  'declined:',
+  'tentative:',
+  'canceled:',
+  'cancelled:',
+];
+
+/** Subject prefixes that indicate automated notifications (case-insensitive). */
+const NOTIFICATION_PREFIXES = [
+  'automatic reply:',
+  'auto-reply:',
+  'out of office:',
+];
+
+/**
+ * Classifies an email result based on its subject line.
+ */
+export function classifyEmailType(subject: string): EmailType {
+  const lower = subject.toLowerCase().trimStart();
+  for (const prefix of CALENDAR_RESPONSE_PREFIXES) {
+    if (lower.startsWith(prefix)) return 'calendar-response';
+  }
+  for (const prefix of NOTIFICATION_PREFIXES) {
+    if (lower.startsWith(prefix)) return 'notification';
+  }
+  return 'email';
+}
+
+/**
+ * Parses a single email result from the Substrate v2 query API response.
+ * 
+ * Email results have a different structure to Teams message results:
+ * - Subject is a top-level field
+ * - From/To/Cc are structured address objects
+ * - Body preview is in HitHighlightedSummary or Preview
+ */
+export function parseEmailResult(item: Record<string, unknown>): EmailSearchResult | null {
+  const source = item.Source as Record<string, unknown> | undefined;
+
+  // Subject from top-level or source
+  const subject = item.Subject as string
+    || source?.Subject as string
+    || '';
+
+  // Preview/body snippet
+  const rawPreview = item.HitHighlightedSummary as string
+    || item.Summary as string
+    || source?.Preview as string
+    || '';
+
+  const links = extractLinks(rawPreview);
+  const preview = stripHtml(rawPreview);
+
+  // Skip results with no meaningful content
+  if (!subject && preview.length < MIN_CONTENT_LENGTH) return null;
+
+  const id = item.Id as string
+    || item.ReferenceId as string
+    || `email-${Date.now()}`;
+
+  // Sender info — Substrate returns From as a structured object or string
+  let sender = '';
+  let senderEmail: string | undefined;
+  const from = source?.From as Record<string, unknown> | string | undefined;
+  if (typeof from === 'string') {
+    sender = from;
+  } else if (from) {
+    const emailAddress = from.EmailAddress as Record<string, unknown> | undefined;
+    if (emailAddress) {
+      sender = emailAddress.Name as string || '';
+      senderEmail = emailAddress.Address as string | undefined;
+    } else {
+      sender = from.Name as string || from.DisplayName as string || '';
+      senderEmail = from.Address as string || from.EmailAddress as string | undefined;
+    }
+  }
+  // Fallback to flat fields
+  if (!sender) {
+    sender = source?.FromName as string || source?.Sender as string || '';
+  }
+  if (!senderEmail) {
+    senderEmail = source?.FromAddress as string || source?.SenderSmtpAddress as string || undefined;
+  }
+
+  // Timestamp
+  const receivedAt = source?.DateTimeReceived as string
+    || source?.DateTimeSent as string
+    || source?.ReceivedTime as string
+    || undefined;
+
+  // Attachments
+  const hasAttachments = typeof source?.HasAttachments === 'boolean'
+    ? source.HasAttachments
+    : typeof source?.HasAttachment === 'boolean'
+      ? source.HasAttachment
+      : undefined;
+
+  // Importance
+  const importance = source?.Importance as string || undefined;
+
+  // Read status
+  const isRead = typeof source?.IsRead === 'boolean' ? source.IsRead as boolean : undefined;
+
+  // Recipients
+  const toRecipients = parseRecipients(source?.ToRecipients ?? source?.DisplayTo);
+  const ccRecipients = parseRecipients(source?.CcRecipients ?? source?.DisplayCc);
+
+  // Web link
+  const webLink = source?.WebLink as string
+    || source?.OwaLink as string
+    || undefined;
+
+  // Conversation ID (email thread) — can be a string or {Id: string} object
+  let conversationId: string | undefined;
+  const rawConvId = source?.ConversationId;
+  if (typeof rawConvId === 'string') {
+    conversationId = rawConvId;
+  } else if (rawConvId && typeof rawConvId === 'object') {
+    conversationId = (rawConvId as Record<string, unknown>).Id as string | undefined;
+  }
+  if (!conversationId) {
+    conversationId = source?.InternetMessageId as string || undefined;
+  }
+
+  return {
+    id,
+    emailType: classifyEmailType(subject),
+    subject,
+    sender,
+    senderEmail,
+    preview,
+    receivedAt,
+    hasAttachments,
+    importance,
+    isRead,
+    toRecipients,
+    ccRecipients,
+    webLink,
+    conversationId,
+    links: links.length > 0 ? links : undefined,
+  };
+}
+
+/**
+ * Parses recipient fields from Substrate email results.
+ * 
+ * Recipients can be:
+ * - A string (e.g., "John Smith; Jane Doe")
+ * - An array of objects with Name/Address fields
+ * - undefined
+ */
+function parseRecipients(recipients: unknown): string[] | undefined {
+  if (!recipients) return undefined;
+
+  if (typeof recipients === 'string') {
+    // Semicolon-separated display names
+    const parsed = recipients.split(';').map(r => r.trim()).filter(Boolean);
+    return parsed.length > 0 ? parsed : undefined;
+  }
+
+  if (Array.isArray(recipients)) {
+    const parsed: string[] = [];
+    for (const r of recipients) {
+      const recipient = r as Record<string, unknown>;
+      const emailAddress = recipient.EmailAddress as Record<string, unknown> | undefined;
+      if (emailAddress) {
+        const name = emailAddress.Name as string;
+        const address = emailAddress.Address as string;
+        parsed.push(name || address || '');
+      } else {
+        const name = recipient.Name as string || recipient.DisplayName as string;
+        const address = recipient.Address as string || recipient.EmailAddress as string;
+        parsed.push(name || address || '');
+      }
+    }
+    const filtered = parsed.filter(Boolean);
+    return filtered.length > 0 ? filtered : undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Parses email search results from the Substrate v2 query API response.
+ * 
+ * Same EntitySets/ResultSets structure as Teams message search, but
+ * items are email messages with different fields.
+ * 
+ * By default, calendar responses (Accepted/Declined/Tentative/Canceled)
+ * are filtered out. Set `excludeCalendarResponses: false` to include them.
+ */
+export function parseEmailSearchResults(
+  entitySets: unknown[] | undefined,
+  options: { excludeCalendarResponses?: boolean } = {},
+): { results: EmailSearchResult[]; total?: number; filteredCount?: number } {
+  const excludeCalendar = options.excludeCalendarResponses ?? true;
+  const results: EmailSearchResult[] = [];
+  let total: number | undefined;
+  let filteredCount = 0;
+
+  if (!Array.isArray(entitySets)) {
+    return { results, total };
+  }
+
+  for (const entitySet of entitySets) {
+    const es = entitySet as Record<string, unknown>;
+    const resultSets = es.ResultSets as unknown[] | undefined;
+
+    if (Array.isArray(resultSets)) {
+      for (const resultSet of resultSets) {
+        const rs = resultSet as Record<string, unknown>;
+
+        const rsTotal = rs.Total ?? rs.TotalCount ?? rs.TotalEstimate;
+        if (typeof rsTotal === 'number') {
+          total = rsTotal;
+        }
+
+        const items = rs.Results as unknown[] | undefined;
+        if (Array.isArray(items)) {
+          for (const item of items) {
+            const parsed = parseEmailResult(item as Record<string, unknown>);
+            if (parsed) {
+              if (excludeCalendar && parsed.emailType === 'calendar-response') {
+                filteredCount++;
+              } else {
+                results.push(parsed);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return { results, total, filteredCount: filteredCount > 0 ? filteredCount : undefined };
 }
 
 /**

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -590,11 +590,12 @@ export function parseEmailResult(item: Record<string, unknown>): EmailSearchResu
     || undefined;
 
   // Attachments
-  const hasAttachments = typeof source?.HasAttachments === 'boolean'
-    ? source.HasAttachments
-    : typeof source?.HasAttachment === 'boolean'
-      ? source.HasAttachment
-      : undefined;
+  let hasAttachments: boolean | undefined;
+  if (typeof source?.HasAttachments === 'boolean') {
+    hasAttachments = source.HasAttachments;
+  } else if (typeof source?.HasAttachment === 'boolean') {
+    hasAttachments = source.HasAttachment;
+  }
 
   // Importance
   const importance = source?.Importance as string || undefined;
@@ -667,15 +668,16 @@ function parseRecipients(recipients: unknown): string[] | undefined {
       if (emailAddress) {
         const name = emailAddress.Name as string;
         const address = emailAddress.Address as string;
-        parsed.push(name || address || '');
+        const display = name || address;
+        if (display) parsed.push(display);
       } else {
         const name = recipient.Name as string || recipient.DisplayName as string;
         const address = recipient.Address as string || recipient.EmailAddress as string;
-        parsed.push(name || address || '');
+        const display = name || address;
+        if (display) parsed.push(display);
       }
     }
-    const filtered = parsed.filter(Boolean);
-    return filtered.length > 0 ? filtered : undefined;
+    return parsed.length > 0 ? parsed : undefined;
   }
 
   return undefined;


### PR DESCRIPTION
## Summary

Add a new `teams_search_email` MCP tool that searches emails in the user's mailbox using the existing Substrate API — no additional authentication required.

## What's New

- **`teams_search_email` tool** — Search emails with the same operators as Outlook (`from:`, `to:`, `subject:`, `sent:`, `hasattachment:`, `is:unread`, etc.)
- **Email type classification** — Each result is tagged with `emailType`: `email`, `calendar-response`, or `notification`
- **Calendar response filtering** — Accepted/Declined/Tentative/Canceled meeting responses are filtered out by default, removing noise from results
- **Full email metadata** — Subject, sender, recipients (To/Cc), preview, read status, importance, attachments, web link, conversation ID

## Implementation

- Uses the same Substrate v2 query endpoint as `teams_search`, with `contentSources: ['Exchange']` and `QueryType: 'Mail'`
- Reuses existing Substrate token (`SubstrateSearch-Internal.ReadWrite` scope)
- `classifyEmailType()` detects calendar responses and auto-replies by subject prefix
- `parseEmailSearchResults()` filters calendar responses by default (opt-out available)
- Response includes `calendarResponsesFiltered` count when items are excluded

## Files Changed

| File | Change |
|------|--------|
| `src/types/teams.ts` | `EmailType` union, `EmailSearchResult` interface |
| `src/utils/parsers.ts` | `classifyEmailType()`, `parseEmailResult()`, `parseEmailSearchResults()` |
| `src/api/substrate-api.ts` | `searchEmails()` function |
| `src/tools/search-tools.ts` | Tool definition, schema, handler |
| `src/__fixtures__/api-responses.ts` | 4 email fixtures + 1 calendar response fixture |
| `src/utils/parsers.test.ts` | 12 new tests (225 total, all passing) |
| `AGENTS.md` | Tool table, auth table, test list |
| `README.md` | Tool table, search operators, CLI example |
| `docs/API-REFERENCE.md` | Full Email Search API section |
| `docs/MANUAL-TEST-SCRIPT.md` | Tool table, workflow, example prompt |

## Testing

- ✅ 225 unit tests passing
- ✅ Build clean (no TS errors)
- ✅ Live tested via CLI harness — verified search, pagination, calendar filtering