### PR TITLE
fix: address code review findings across 14 files

### DIFF
--- a/src/api/calendar-api.ts
+++ b/src/api/calendar-api.ts
@@ -208,7 +208,7 @@ export async function getCalendarView(
 
   const startDate = options.startDate || now.toISOString();
   const endDate = options.endDate || defaultEnd.toISOString();
-  const limit = options.limit || DEFAULT_MEETING_LIMIT;
+  const limit = options.limit ?? DEFAULT_MEETING_LIMIT;
 
   // Build query parameters
   const params = new URLSearchParams({

--- a/src/api/chatsvc-messaging.ts
+++ b/src/api/chatsvc-messaging.ts
@@ -137,8 +137,7 @@ export async function sendMessage(
   const { replyToMessageId } = options;
   const displayName = getUserDisplayName() || 'User';
 
-  // Generate unique message ID
-  const clientMessageId = Date.now().toString();
+  const clientMessageId = crypto.randomUUID();
 
   // Process content: handle mentions, links, and markdown formatting.
   // Always convert through markdown→HTML pipeline (never pass user content through

--- a/src/browser/auth.ts
+++ b/src/browser/auth.ts
@@ -432,7 +432,8 @@ async function checkBrowserTokenExpiry(page: Page): Promise<number> {
           if (!secret?.startsWith('ey')) continue;
 
           // Decode JWT exp claim
-          const payload = JSON.parse(atob(secret.split('.')[1]));
+          const b64 = secret.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+          const payload = JSON.parse(atob(b64));
           if (typeof payload.exp !== 'number') continue;
 
           const expiryMs = payload.exp * 1000;

--- a/src/server.ts
+++ b/src/server.ts
@@ -478,7 +478,11 @@ export async function runServer(): Promise<void> {
 
   // Handle shutdown signals
   const shutdown = async () => {
-    await teamsServer.cleanup();
+    try {
+      await teamsServer.cleanup();
+    } catch {
+      // Ignore cleanup errors during shutdown
+    }
     process.exit(0);
   };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -481,7 +481,10 @@ export async function runServer(): Promise<void> {
     try {
       await teamsServer.cleanup();
     } catch {
-      // Ignore cleanup errors during shutdown
+    } catch (err) {
+      // Best-effort cleanup — log but don't block shutdown
+      console.error('[shutdown] cleanup error (ignored):', err);
+    }
     }
     process.exit(0);
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -480,11 +480,9 @@ export async function runServer(): Promise<void> {
   const shutdown = async () => {
     try {
       await teamsServer.cleanup();
-    } catch {
     } catch (err) {
       // Best-effort cleanup — log but don't block shutdown
       console.error('[shutdown] cleanup error (ignored):', err);
-    }
     }
     process.exit(0);
   };

--- a/src/test/mcp-harness.ts
+++ b/src/test/mcp-harness.ts
@@ -118,7 +118,8 @@ function parseArgs(): ParsedArgs {
         i++;
         break;
       }
-      i++;
+      // Skip --flag and its value
+      i += 2;
     }
   } else if (result.command !== 'list') {
     // Treat as a tool name (add teams_ prefix if not present)

--- a/src/tools/file-tools.ts
+++ b/src/tools/file-tools.ts
@@ -17,7 +17,7 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const GetSharedFilesInputSchema = z.object({
-  conversationId: z.string(),
+  conversationId: z.string().min(1),
   pageSize: z.number().min(1).max(MAX_FILES_PAGE_SIZE).optional().default(DEFAULT_FILES_PAGE_SIZE),
   skipToken: z.string().optional(),
 });

--- a/src/tools/meeting-tools.ts
+++ b/src/tools/meeting-tools.ts
@@ -24,7 +24,7 @@ export const GetMeetingsInputSchema = z.object({
 });
 
 export const GetTranscriptInputSchema = z.object({
-  threadId: z.string(),
+  threadId: z.string().min(1),
   meetingDate: z.string().optional(),
 });
 

--- a/src/tools/message-tools.ts
+++ b/src/tools/message-tools.ts
@@ -67,7 +67,7 @@ export const DeleteMessageInputSchema = z.object({
 });
 
 export const GetUnreadInputSchema = z.object({
-  conversationId: z.string().optional(),
+  conversationId: z.string().min(1).optional(),
 });
 
 export const MarkAsReadInputSchema = z.object({

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -7,6 +7,7 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { z } from 'zod';
 import type { ToolContext, ToolResult } from './index.js';
+import { ErrorCode, createError } from '../types/errors.js';
 
 /** Type-erased tool entry for the registry — avoids generic variance issues. */
 interface RegistryEntry {
@@ -70,13 +71,19 @@ export async function invokeTool(
   const tool = toolsByName.get(name);
   
   if (!tool) {
-    throw new Error(`Unknown tool: ${name}`);
+    return {
+      success: false,
+      error: createError(ErrorCode.INVALID_INPUT, `Unknown tool: ${name}`, { retryable: false }),
+    };
   }
 
   // Validate input
   const parseResult = tool.schema.safeParse(args);
   if (!parseResult.success) {
-    throw new Error(`Invalid input: ${parseResult.error.message}`);
+    return {
+      success: false,
+      error: createError(ErrorCode.INVALID_INPUT, `Invalid input: ${parseResult.error.message}`, { retryable: false }),
+    };
   }
 
   // Invoke handler

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -157,10 +157,7 @@ export function extractRetryAfter(headers: Headers): number | undefined {
   }
   
   // Try parsing as HTTP date
-  try {
-    const date = new Date(retryAfter);
-    return Math.max(0, date.getTime() - Date.now());
-  } catch {
-    return undefined;
-  }
+  const date = new Date(retryAfter);
+  if (isNaN(date.getTime())) return undefined;
+  return Math.max(0, date.getTime() - Date.now());
 }

--- a/src/utils/auth-guards.ts
+++ b/src/utils/auth-guards.ts
@@ -52,7 +52,7 @@ export interface CsaAuthInfo {
  */
 function shouldRefreshSubstrateToken(): boolean {
   const substrate = extractSubstrateToken();
-  if (!substrate) return false;
+  if (!substrate) return true;
 
   const timeRemaining = substrate.expiry.getTime() - Date.now();
   // Refresh if expired (timeRemaining <= 0) OR approaching expiry

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -85,11 +85,12 @@ export async function httpRequest<T = unknown>(
         return result;
       }
 
-      // Calculate backoff delay
-      const delay = Math.min(
+      // Calculate backoff delay with jitter to avoid thundering herd
+      const baseDelay = Math.min(
         retryBaseDelayMs * Math.pow(2, attempt - 1),
         retryMaxDelayMs
       );
+      const delay = baseDelay * (0.5 + Math.random() * 0.5);
       
       await sleep(delay);
       

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -6,7 +6,7 @@
  * - Log levels can be controlled via LOG_LEVEL environment variable
  * - Future structured logging can be added in one place
  * 
- * Levels: error (default) | warn | info | debug
+ * Levels: error | warn | info (default) | debug
  * Set LOG_LEVEL=debug for verbose output during development.
  */
 

--- a/src/utils/parsers-search.ts
+++ b/src/utils/parsers-search.ts
@@ -19,7 +19,7 @@ export function parseV2Result(item: Record<string, unknown>, linkContext?: LinkC
 
   const id = item.Id as string || 
              item.ReferenceId as string || 
-             `v2-${Date.now()}`;
+             `v2-${crypto.randomUUID()}`;
 
   // Extract links before stripping HTML
   const links = extractLinks(content);


### PR DESCRIPTION
## Summary

Addresses code review feedback with bug fixes, robustness improvements, and code quality cleanups across 14 source files. No new features or breaking changes.

## Bug Fixes

- **`calendar-api.ts`** — Use nullish coalescing (`??`) instead of logical OR (`||`) for `options.limit`, so that an explicit `limit: 0` is respected rather than falling through to the default value.
- **`auth-guards.ts`** — Fix `shouldRefreshSubstrateToken()` to return `true` when no token exists. Previously returned `false`, which skipped the refresh attempt entirely — meaning a missing token could never be recovered.
- **`browser/auth.ts`** — Add base64url-to-base64 conversion (`-` → `+`, `_` → `/`) before calling `atob()` for JWT decoding. Some tokens use URL-safe base64 encoding, which `atob()` silently mishandles without this conversion.
- **`test/mcp-harness.ts`** — Fix CLI argument parsing: increment by 2 (`i += 2`) when consuming `--flag value` pairs, so the value isn't misinterpreted as a positional argument or command name.

## Robustness Improvements

- **`chatsvc-messaging.ts`** / **`parsers-search.ts`** — Replace `Date.now().toString()` with `crypto.randomUUID()` for generating message IDs and fallback search result IDs. `Date.now()` has millisecond resolution and can produce collisions when multiple operations happen in quick succession.
- **`http.ts`** — Add jitter (0.5–1.0x multiplier) to the exponential backoff delay in `httpRequest()` to prevent thundering herd problems when multiple requests retry simultaneously.
- **`server.ts`** — Wrap `teamsServer.cleanup()` in a try/catch in the shutdown signal handler. Cleanup errors during process exit should not cause an unhandled exception or prevent the process from terminating.
- **`file-tools.ts`** / **`meeting-tools.ts`** / **`message-tools.ts`** — Add `.min(1)` validation to string ID parameters (`conversationId`, `threadId`) in Zod schemas to reject empty strings early, before they reach the API layer and cause confusing errors.
- **`registry.ts`** — Return structured `McpError` results (via `createError()`) instead of throwing plain `Error` for unknown tool names and invalid input. This is consistent with the project's `Result<T, McpError>` error handling pattern and gives LLMs actionable error information with `retryable` flags and error codes.

## Code Quality

- **`errors.ts`** — Replace try/catch with `isNaN()` check in `extractRetryAfter()`. `new Date(invalidString)` never throws — it returns an `Invalid Date` object — so the try/catch was dead code that gave a false sense of safety.
- **`logger.ts`** — Fix doc comment to reflect the actual default log level (`info`, not `error`).

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Manual verification with `npm run cli -- status` and `npm run cli -- search "test"`

Made with [Cursor](https://cursor.com)