### PR TITLE
Add test coverage for HTTP utils, logger, API config, and tool registry

### DIFF
--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for tools/registry.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+
+// Mock the MCP SDK
+vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
+  Tool: {},
+}));
+
+vi.mock('./search-tools.js', () => ({
+  searchTools: [{
+    definition: { name: 'teams_search_messages' },
+    schema: z.object({ query: z.string() }),
+    handler: vi.fn().mockResolvedValue({ success: true }),
+  }],
+}));
+
+vi.mock('./message-tools.js', () => ({
+  messageTools: [{
+    definition: { name: 'teams_send_message' },
+    schema: z.object({ conversationId: z.string(), content: z.string() }),
+    handler: vi.fn().mockResolvedValue({ success: true }),
+  }],
+}));
+
+vi.mock('./people-tools.js', () => ({
+  peopleTools: [{
+    definition: { name: 'teams_get_user' },
+    schema: z.object({ userId: z.string() }),
+    handler: vi.fn().mockResolvedValue({ success: true }),
+  }],
+}));
+
+vi.mock('./auth-tools.js', () => ({
+  authTools: [{
+    definition: { name: 'teams_login' },
+    schema: z.object({}),
+    handler: vi.fn().mockResolvedValue({ success: true }),
+  }],
+}));
+
+vi.mock('./meeting-tools.js', () => ({
+  meetingTools: [{
+    definition: { name: 'teams_list_meetings' },
+    schema: z.object({}),
+    handler: vi.fn().mockResolvedValue({ success: true }),
+  }],
+}));
+
+vi.mock('./file-tools.js', () => ({
+  fileTools: [{
+    definition: { name: 'teams_upload_file' },
+    schema: z.object({}),
+    handler: vi.fn().mockResolvedValue({ success: true }),
+  }],
+}));
+
+import { getToolDefinitions, getTool, invokeTool, hasTool } from './registry.js';
+
+describe('getToolDefinitions', () => {
+  it('returns an array of tool definitions', () => {
+    const tools = getToolDefinitions();
+    
+    expect(Array.isArray(tools)).toBe(true);
+    expect(tools.length).toBeGreaterThan(0);
+  });
+
+  it('returns tools with expected properties', () => {
+    const tools = getToolDefinitions();
+    
+    for (const tool of tools) {
+      expect(tool).toHaveProperty('name');
+      expect(typeof tool.name).toBe('string');
+    }
+  });
+});
+
+describe('getTool', () => {
+  it('returns a tool by name', () => {
+    const tool = getTool('teams_search_messages');
+    
+    expect(tool).toBeDefined();
+    expect(tool?.definition.name).toBe('teams_search_messages');
+  });
+
+  it('returns undefined for unknown tool', () => {
+    const tool = getTool('nonexistent_tool');
+    
+    expect(tool).toBeUndefined();
+  });
+});
+
+describe('hasTool', () => {
+  it('returns true for existing tool', () => {
+    expect(hasTool('teams_search_messages')).toBe(true);
+  });
+
+  it('returns false for unknown tool', () => {
+    expect(hasTool('nonexistent_tool')).toBe(false);
+  });
+});
+
+describe('invokeTool', () => {
+  const mockContext = {
+    session: { tokens: { skype: 'test', auth: 'test' } } as any,
+    config: { teamsBaseUrl: 'https://teams.microsoft.com' },
+  };
+
+  it('invokes a known tool', async () => {
+    const result = await invokeTool('teams_search_messages', { query: 'test' }, mockContext);
+    
+    expect(result.success).toBe(true);
+  });
+
+  it('returns error for unknown tool', async () => {
+    const result = await invokeTool('nonexistent_tool', {}, mockContext);
+    
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe('INVALID_INPUT');
+      expect(result.error.message).toContain('Unknown tool');
+    }
+  });
+
+  it('validates input against schema', async () => {
+    const result = await invokeTool('teams_search_messages', { query: 'test' }, mockContext);
+    
+    expect(result).toBeDefined();
+    expect(result.success).toBe(true);
+  });
+
+  it('returns validation error for invalid input', async () => {
+    // teams_search_messages requires a string query
+    const result = await invokeTool('teams_search_messages', { query: 123 } as any, mockContext);
+    
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe('INVALID_INPUT');
+      expect(result.error.message).toContain('Invalid input');
+    }
+  });
+});

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
+import type { ToolContext } from './index.js';
 
 // Mock the MCP SDK
 vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
@@ -104,8 +105,14 @@ describe('hasTool', () => {
 });
 
 describe('invokeTool', () => {
-  const mockContext = {
-    server: {} as { browser: () => Promise<unknown> },
+  const mockContext: ToolContext = {
+    server: {
+      ensureBrowser: async () => ({} as never),
+      resetBrowserState: () => {},
+      getBrowserManager: () => null,
+      setBrowserManager: () => {},
+      markInitialised: () => {},
+    },
   };
 
   it('invokes a known tool', async () => {

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for tools/registry.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
 
 // Mock the MCP SDK
@@ -105,8 +105,7 @@ describe('hasTool', () => {
 
 describe('invokeTool', () => {
   const mockContext = {
-    session: { tokens: { skype: 'test', auth: 'test' } } as any,
-    config: { teamsBaseUrl: 'https://teams.microsoft.com' },
+    server: {} as { browser: () => Promise<unknown> },
   };
 
   it('invokes a known tool', async () => {
@@ -134,7 +133,7 @@ describe('invokeTool', () => {
 
   it('returns validation error for invalid input', async () => {
     // teams_search_messages requires a string query
-    const result = await invokeTool('teams_search_messages', { query: 123 } as any, mockContext);
+    const result = await invokeTool('teams_search_messages', { query: 123 } as Record<string, unknown>, mockContext);
     
     expect(result.success).toBe(false);
     if (!result.success) {

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -112,6 +112,7 @@ describe('invokeTool', () => {
       getBrowserManager: () => null,
       setBrowserManager: () => {},
       markInitialised: () => {},
+      isInitialisedState: () => false,
     },
   };
 

--- a/src/utils/api-config.test.ts
+++ b/src/utils/api-config.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for api-config utilities.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_TEAMS_BASE_URL,
+  DEFAULT_SUBSTRATE_BASE_URL,
+  SUBSTRATE_API,
+  CHATSVC_API,
+  CALENDAR_API,
+  CSA_API,
+  getTeamsHeaders,
+  getBearerHeaders,
+  getSkypeAuthHeaders,
+  getCsaHeaders,
+  getMessagingHeaders,
+} from './api-config.js';
+
+describe('DEFAULT_TEAMS_BASE_URL', () => {
+  it('has a valid commercial teams URL', () => {
+    expect(DEFAULT_TEAMS_BASE_URL).toBe('https://teams.microsoft.com');
+  });
+});
+
+describe('DEFAULT_SUBSTRATE_BASE_URL', () => {
+  it('has a valid commercial substrate URL', () => {
+    expect(DEFAULT_SUBSTRATE_BASE_URL).toBe('https://substrate.office.com');
+  });
+});
+
+describe('SUBSTRATE_API', () => {
+  it('has search endpoint', () => {
+    expect(SUBSTRATE_API.search).toContain('substrate.office.com');
+    expect(SUBSTRATE_API.search).toContain('query');
+  });
+
+  it('has suggestions endpoint', () => {
+    expect(SUBSTRATE_API.suggestions).toContain('substrate.office.com');
+    expect(SUBSTRATE_API.suggestions).toContain('suggestions');
+  });
+
+  it('has frequent contacts endpoint', () => {
+    expect(SUBSTRATE_API.frequentContacts).toContain('peoplecache');
+  });
+
+  it('has people search endpoint', () => {
+    expect(SUBSTRATE_API.peopleSearch).toContain('powerbar');
+  });
+
+  it('has channel search endpoint', () => {
+    expect(SUBSTRATE_API.channelSearch).toContain('TeamsChannel');
+  });
+});
+
+describe('CHATSVC_API', () => {
+  it('builds messages URL', () => {
+    const url = CHATSVC_API.messages('amer-02', '19:abc@thread.tacv2');
+    expect(url).toContain('chatsvc');
+    expect(url).toContain('amer-02');
+    expect(url).toContain('19%3Aabc%40thread.tacv2');
+  });
+
+  it('builds messages URL with replyToMessageId', () => {
+    const url = CHATSVC_API.messages('amer-02', '19:abc@thread.tacv2', '1705760000000');
+    // URL is encoded: %3B is semicolon, %3D is equals
+    expect(url).toContain('%3Bmessageid%3D1705760000000');
+  });
+
+  it('builds conversation URL', () => {
+    const url = CHATSVC_API.conversation('amer-02', '19:abc@thread.tacv2');
+    expect(url).toContain('conversations');
+    expect(url).toContain('19%3Aabc%40thread.tacv2');
+  });
+
+  it('builds messageMetadata URL', () => {
+    const url = CHATSVC_API.messageMetadata('amer-02', '19:abc@thread.tacv2', 'msg123');
+    expect(url).toContain('rcmetadata');
+    expect(url).toContain('msg123');
+  });
+
+  it('builds editMessage URL', () => {
+    const url = CHATSVC_API.editMessage('amer-02', '19:abc@thread.tacv2', 'msg123');
+    expect(url).toContain('messages');
+    expect(url).toContain('msg123');
+  });
+
+  it('builds deleteMessage URL', () => {
+    const url = CHATSVC_API.deleteMessage('amer-02', '19:abc@thread.tacv2', 'msg123');
+    expect(url).toContain('softDelete');
+  });
+
+  it('builds consumptionHorizons URL', () => {
+    const url = CHATSVC_API.consumptionHorizons('amer-02', '19:abc@thread.tacv2');
+    expect(url).toContain('consumptionhorizons');
+  });
+
+  it('builds updateConsumptionHorizon URL', () => {
+    const url = CHATSVC_API.updateConsumptionHorizon('amer-02', '19:abc@thread.tacv2');
+    expect(url).toContain('consumptionhorizon');
+  });
+
+  it('builds activityFeed URL', () => {
+    const url = CHATSVC_API.activityFeed('amer-02');
+    expect(url).toContain('conversations');
+  });
+
+  it('builds messageEmotions URL', () => {
+    const url = CHATSVC_API.messageEmotions('amer-02', '19:abc@thread.tacv2', 'msg123');
+    expect(url).toContain('emotions');
+  });
+
+  it('builds createThread URL', () => {
+    const url = CHATSVC_API.createThread('amer-02');
+    expect(url).toContain('threads');
+  });
+
+  it('builds singleMessage URL', () => {
+    const url = CHATSVC_API.singleMessage('amer-02', '19:abc@thread.tacv2', 'msg123');
+    expect(url).toContain('msg123');
+  });
+
+  it('accepts custom baseUrl for GCC support', () => {
+    const url = CHATSVC_API.messages('amer-02', '19:abc@thread.tacv2', undefined, 'https://teams.microsoft.us');
+    expect(url).toContain('teams.microsoft.us');
+  });
+});
+
+describe('CALENDAR_API', () => {
+  it('builds calendarView URL with partition', () => {
+    const url = CALENDAR_API.calendarView('amer-02', true);
+    expect(url).toContain('/mt/part/');
+    expect(url).toContain('amer-02');
+    expect(url).toContain('calendarView');
+  });
+
+  it('builds calendarView URL without partition', () => {
+    const url = CALENDAR_API.calendarView('emea', false);
+    expect(url).toContain('/mt/emea');
+    expect(url).toContain('calendarView');
+  });
+
+  it('accepts custom baseUrl', () => {
+    const url = CALENDAR_API.calendarView('amer-02', true, 'https://teams.microsoft.us');
+    expect(url).toContain('teams.microsoft.us');
+  });
+});
+
+describe('CSA_API', () => {
+  it('builds conversationFolders URL', () => {
+    const url = CSA_API.conversationFolders('amer-02');
+    expect(url).toContain('csa');
+    expect(url).toContain('conversationFolders');
+  });
+
+  it('builds teamsList URL', () => {
+    const url = CSA_API.teamsList('amer-02');
+    expect(url).toContain('teams');
+    expect(url).toContain('api/v3');
+  });
+
+  it('builds customEmojis URL', () => {
+    const url = CSA_API.customEmojis('amer-02');
+    expect(url).toContain('customemoji');
+    expect(url).toContain('metadata');
+  });
+
+  it('accepts custom baseUrl for government clouds', () => {
+    const url = CSA_API.teamsList('amer-02', 'https://teams.microsoft.us');
+    expect(url).toContain('teams.microsoft.us');
+  });
+});
+
+describe('getTeamsHeaders', () => {
+  it('returns headers with content-type and origin', () => {
+    const headers = getTeamsHeaders();
+    
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers['Accept']).toBe('application/json');
+    expect(headers['Origin']).toBe(DEFAULT_TEAMS_BASE_URL);
+    expect(headers['Referer']).toBe(`${DEFAULT_TEAMS_BASE_URL}/`);
+  });
+
+  it('uses custom baseUrl for origin and referer', () => {
+    const headers = getTeamsHeaders('https://teams.microsoft.us');
+    
+    expect(headers['Origin']).toBe('https://teams.microsoft.us');
+    expect(headers['Referer']).toBe('https://teams.microsoft.us/');
+  });
+});
+
+describe('getBearerHeaders', () => {
+  it('adds Authorization header', () => {
+    const headers = getBearerHeaders('my-token');
+    
+    expect(headers['Authorization']).toBe('Bearer my-token');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('uses custom baseUrl', () => {
+    const headers = getBearerHeaders('my-token', 'https://teams.microsoft.us');
+    
+    expect(headers['Origin']).toBe('https://teams.microsoft.us');
+  });
+});
+
+describe('getSkypeAuthHeaders', () => {
+  it('adds both skypetoken and Authorization headers', () => {
+    const headers = getSkypeAuthHeaders('skype-token', 'bearer-token');
+    
+    expect(headers['Authentication']).toBe('skypetoken=skype-token');
+    expect(headers['Authorization']).toBe('Bearer bearer-token');
+  });
+});
+
+describe('getCsaHeaders', () => {
+  it('adds skypetoken and CSA bearer headers', () => {
+    const headers = getCsaHeaders('skype-token', 'csa-token');
+    
+    expect(headers['Authentication']).toBe('skypetoken=skype-token');
+    expect(headers['Authorization']).toBe('Bearer csa-token');
+  });
+});
+
+describe('getMessagingHeaders', () => {
+  it('includes client version header', () => {
+    const headers = getMessagingHeaders('skype-token', 'bearer-token');
+    
+    expect(headers['X-Ms-Client-Version']).toBeDefined();
+    expect(headers['X-Ms-Client-Version']).toMatch(/^\d+\/\d+\.\d+\.\d+/);
+  });
+
+  it('includes skypetoken and authorization', () => {
+    const headers = getMessagingHeaders('skype-token', 'bearer-token');
+    
+    expect(headers['Authentication']).toContain('skypetoken');
+    expect(headers['Authorization']).toContain('Bearer');
+  });
+});

--- a/src/utils/api-config.ts
+++ b/src/utils/api-config.ts
@@ -174,7 +174,7 @@ export function getTeamsHeaders(baseUrl = DEFAULT_TEAMS_BASE_URL): Record<string
 }
 
 /** Headers for Bearer token authentication. */
-export function getBearerHeaders(token: string, baseUrl = DEFAULT_TEAMS_BASE_URL): HeadersInit {
+export function getBearerHeaders(token: string, baseUrl = DEFAULT_TEAMS_BASE_URL): Record<string, string> {
   return {
     ...getTeamsHeaders(baseUrl),
     'Authorization': `Bearer ${token}`,
@@ -182,7 +182,7 @@ export function getBearerHeaders(token: string, baseUrl = DEFAULT_TEAMS_BASE_URL
 }
 
 /** Headers for Skype token + Bearer authentication. */
-export function getSkypeAuthHeaders(skypeToken: string, authToken: string, baseUrl = DEFAULT_TEAMS_BASE_URL): HeadersInit {
+export function getSkypeAuthHeaders(skypeToken: string, authToken: string, baseUrl = DEFAULT_TEAMS_BASE_URL): Record<string, string> {
   return {
     ...getTeamsHeaders(baseUrl),
     'Authentication': `skypetoken=${skypeToken}`,
@@ -191,7 +191,7 @@ export function getSkypeAuthHeaders(skypeToken: string, authToken: string, baseU
 }
 
 /** Headers for CSA API (Skype token + CSA Bearer). */
-export function getCsaHeaders(skypeToken: string, csaToken: string, baseUrl = DEFAULT_TEAMS_BASE_URL): HeadersInit {
+export function getCsaHeaders(skypeToken: string, csaToken: string, baseUrl = DEFAULT_TEAMS_BASE_URL): Record<string, string> {
   return {
     ...getTeamsHeaders(baseUrl),
     'Authentication': `skypetoken=${skypeToken}`,
@@ -200,7 +200,7 @@ export function getCsaHeaders(skypeToken: string, csaToken: string, baseUrl = DE
 }
 
 /** Client version header for messaging API. */
-export function getMessagingHeaders(skypeToken: string, authToken: string, baseUrl = DEFAULT_TEAMS_BASE_URL): HeadersInit {
+export function getMessagingHeaders(skypeToken: string, authToken: string, baseUrl = DEFAULT_TEAMS_BASE_URL): Record<string, string> {
   return {
     ...getSkypeAuthHeaders(skypeToken, authToken, baseUrl),
     'X-Ms-Client-Version': '1415/1.0.0.2025010401',

--- a/src/utils/api-config.ts
+++ b/src/utils/api-config.ts
@@ -164,7 +164,7 @@ export const CSA_API = {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** Common request headers for Teams API calls. */
-export function getTeamsHeaders(baseUrl = DEFAULT_TEAMS_BASE_URL): HeadersInit {
+export function getTeamsHeaders(baseUrl = DEFAULT_TEAMS_BASE_URL): Record<string, string> {
   return {
     'Content-Type': 'application/json',
     'Accept': 'application/json',

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -275,7 +275,7 @@ describe('clearRateLimitState', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
       new Response('Rate Limited', {
         status: 429,
-        headers: { 'Retry-After': '1' },
+        headers: { 'Retry-After': '60' },
       })
     ));
 

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -215,7 +215,7 @@ describe('httpRequest', () => {
     vi.mocked(fetch).mockResolvedValue(
       new Response('Rate Limited', {
         status: 429,
-        headers: { 'Retry-After': '1' },
+        headers: { 'Retry-After': '60' },
       })
     );
 

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Unit tests for HTTP utilities.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { httpRequest, clearRateLimitState, type HttpResponse } from './http.js';
+
+describe('httpRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+    clearRateLimitState();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns successful response on HTTP 200', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await httpRequest('https://api.example.com/data');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.status).toBe(200);
+      expect(result.value.data).toEqual({ ok: true });
+    }
+  });
+
+  it('returns error on HTTP 400', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('Bad Request', { status: 400 })
+    );
+
+    const result = await httpRequest('https://api.example.com/data');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('INVALID_INPUT');
+    }
+  });
+
+  it('returns error on HTTP 401', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('Unauthorized', { status: 401 })
+    );
+
+    const result = await httpRequest('https://api.example.com/data');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('AUTH_EXPIRED');
+    }
+  });
+
+  it('returns error on HTTP 403', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('Forbidden', { status: 403 })
+    );
+
+    const result = await httpRequest('https://api.example.com/data');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('AUTH_REQUIRED');
+    }
+  });
+
+  it('returns error on HTTP 404', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('Not Found', { status: 404 })
+    );
+
+    const result = await httpRequest('https://api.example.com/data');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('NOT_FOUND');
+    }
+  });
+
+  it('returns error on HTTP 429 with retry-after header', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('Rate Limited', {
+        status: 429,
+        headers: { 'Retry-After': '5' },
+      })
+    );
+
+    const result = await httpRequest('https://api.example.com/data');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('RATE_LIMITED');
+      expect(result.error.retryAfterMs).toBe(5000);
+    }
+  });
+
+  it('returns error on HTTP 500', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('Server Error', { status: 500 })
+    );
+
+    const result = await httpRequest('https://api.example.com/data');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('API_ERROR');
+    }
+  });
+
+  it('returns TIMEOUT error on request timeout', async () => {
+    vi.mocked(fetch).mockImplementation(() => 
+      new Promise((_, reject) => {
+        const error = new Error('Request timed out');
+        error.name = 'AbortError';
+        reject(error);
+      })
+    );
+
+    const result = await httpRequest('https://api.example.com/slow', {
+      timeoutMs: 100,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('TIMEOUT');
+    }
+  });
+
+  it('returns NETWORK_ERROR on ECONNRESET', async () => {
+    vi.mocked(fetch).mockImplementation(() => 
+      Promise.reject(new Error('ECONNRESET'))
+    );
+
+    const result = await httpRequest('https://api.example.com/data');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('NETWORK_ERROR');
+    }
+  });
+
+  it('retries on retryable errors', async () => {
+    let attempts = 0;
+    vi.mocked(fetch).mockImplementation(() => {
+      attempts++;
+      if (attempts < 3) {
+        return Promise.reject(new Error('ECONNRESET'));
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    });
+
+    const result = await httpRequest('https://api.example.com/data', {
+      maxRetries: 3,
+      retryBaseDelayMs: 10,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(attempts).toBe(3);
+  });
+
+  it('does not retry on non-retryable errors like 400', async () => {
+    let attempts = 0;
+    vi.mocked(fetch).mockImplementation(() => {
+      attempts++;
+      return Promise.resolve(
+        new Response('Bad Request', { status: 400 })
+      );
+    });
+
+    const result = await httpRequest('https://api.example.com/data');
+
+    expect(result.ok).toBe(false);
+    expect(attempts).toBe(1); // Should not retry
+  });
+
+  it('uses default timeout of 30 seconds', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('{}', { status: 200 })
+    );
+
+    await httpRequest('https://api.example.com/data');
+
+    // Fetch was called - default timeout was applied
+    expect(vi.mocked(fetch)).toHaveBeenCalled();
+  });
+
+  it('accepts custom timeout', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('{}', { status: 200 })
+    );
+
+    await httpRequest('https://api.example.com/data', {
+      timeoutMs: 5000,
+    });
+
+    expect(vi.mocked(fetch)).toHaveBeenCalled();
+  });
+
+  it('returns RATE_LIMITED error when rate limited', async () => {
+    // First, simulate a rate limit response
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('Rate Limited', {
+        status: 429,
+        headers: { 'Retry-After': '1' },
+      })
+    );
+
+    // First request triggers rate limit state
+    await httpRequest('https://api.example.com/data');
+
+    // Replace fetch mock for the second request to verify rate limit check
+    vi.mocked(fetch).mockClear();
+    
+    // Second request should be rate limited without calling fetch
+    const result = await httpRequest('https://api.example.com/data');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('RATE_LIMITED');
+    }
+    // Should not have called fetch since we were rate limited
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('handles plain text response', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('plain text response', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      })
+    );
+
+    const result = await httpRequest('https://api.example.com/text');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.data).toBe('plain text response');
+    }
+  });
+
+  it('handles response without content-type header', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('no content type', { status: 200 })
+    );
+
+    const result = await httpRequest('https://api.example.com/data');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.data).toBe('no content type');
+    }
+  });
+});
+
+describe('clearRateLimitState', () => {
+  beforeEach(() => {
+    clearRateLimitState();
+  });
+
+  it('clears rate limit state', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('Rate Limited', {
+        status: 429,
+        headers: { 'Retry-After': '1' },
+      })
+    ));
+
+    // First request triggers rate limit
+    await httpRequest('https://api.example.com/data');
+
+    // Clear the rate limit state
+    clearRateLimitState();
+
+    // Second request should work
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+
+    const result = await httpRequest('https://api.example.com/data');
+    expect(result.ok).toBe(true);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { httpRequest, clearRateLimitState, type HttpResponse } from './http.js';
+import { httpRequest, clearRateLimitState } from './http.js';
 
 describe('httpRequest', () => {
   beforeEach(() => {

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -175,8 +175,8 @@ describe('logger', () => {
       expect(consoleSpy.debug).toHaveBeenCalled();
     });
 
-    it('defaults to info for unknown level', () => {
-      // Set an invalid level via env (simulated by calling with valid level first)
+    it('logs info level when set to info', () => {
+      // Set info level
       setLogLevel('info');
       
       info('c', 'test');

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for logger utilities.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { error, warn, info, debug, setLogLevel } from './logger.js';
+
+describe('logger', () => {
+  let consoleSpy: {
+    error: ReturnType<typeof vi.spyOn>;
+    warn: ReturnType<typeof vi.spyOn>;
+    log: ReturnType<typeof vi.spyOn>;
+    debug: ReturnType<typeof vi.spyOn>;
+  };
+
+  beforeEach(() => {
+    consoleSpy = {
+      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+      debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+    };
+    // Reset to default log level before each test
+    setLogLevel('info');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('error', () => {
+    it('logs error messages with context', () => {
+      error('test-context', 'Something went wrong');
+      
+      expect(consoleSpy.error).toHaveBeenCalledWith('[test-context] Something went wrong');
+    });
+
+    it('logs even when level is above error', () => {
+      setLogLevel('error');
+      
+      error('context', 'error message');
+      
+      expect(consoleSpy.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('warn', () => {
+    it('logs warning messages with context', () => {
+      warn('test-context', 'This is a warning');
+      
+      expect(consoleSpy.warn).toHaveBeenCalledWith('[test-context] This is a warning');
+    });
+
+    it('does not log when level is error', () => {
+      setLogLevel('error');
+      
+      warn('context', 'warning');
+      
+      expect(consoleSpy.warn).not.toHaveBeenCalled();
+    });
+
+    it('logs when level is warn', () => {
+      setLogLevel('warn');
+      
+      warn('context', 'warning');
+      
+      expect(consoleSpy.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('info', () => {
+    it('logs info messages with context', () => {
+      info('test-context', 'Information message');
+      
+      expect(consoleSpy.log).toHaveBeenCalledWith('[test-context] Information message');
+    });
+
+    it('does not log when level is warn', () => {
+      setLogLevel('warn');
+      
+      info('context', 'info message');
+      
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+    });
+
+    it('logs when level is info', () => {
+      setLogLevel('info');
+      
+      info('context', 'info message');
+      
+      expect(consoleSpy.log).toHaveBeenCalled();
+    });
+  });
+
+  describe('debug', () => {
+    it('logs debug messages with context', () => {
+      setLogLevel('debug');
+      
+      debug('test-context', 'Debug message');
+      
+      expect(consoleSpy.debug).toHaveBeenCalledWith('[test-context] Debug message');
+    });
+
+    it('does not log when level is info', () => {
+      setLogLevel('info');
+      
+      debug('context', 'debug message');
+      
+      expect(consoleSpy.debug).not.toHaveBeenCalled();
+    });
+
+    it('logs when level is debug', () => {
+      setLogLevel('debug');
+      
+      debug('context', 'debug message');
+      
+      expect(consoleSpy.debug).toHaveBeenCalled();
+    });
+  });
+
+  describe('setLogLevel', () => {
+    it('sets log level to error', () => {
+      setLogLevel('error');
+      
+      error('c', 'error');
+      warn('c', 'warn');
+      info('c', 'info');
+      debug('c', 'debug');
+      
+      expect(consoleSpy.error).toHaveBeenCalled();
+      expect(consoleSpy.warn).not.toHaveBeenCalled();
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+      expect(consoleSpy.debug).not.toHaveBeenCalled();
+    });
+
+    it('sets log level to warn', () => {
+      setLogLevel('warn');
+      
+      error('c', 'error');
+      warn('c', 'warn');
+      info('c', 'info');
+      debug('c', 'debug');
+      
+      expect(consoleSpy.error).toHaveBeenCalled();
+      expect(consoleSpy.warn).toHaveBeenCalled();
+      expect(consoleSpy.log).not.toHaveBeenCalled();
+      expect(consoleSpy.debug).not.toHaveBeenCalled();
+    });
+
+    it('sets log level to info', () => {
+      setLogLevel('info');
+      
+      error('c', 'error');
+      warn('c', 'warn');
+      info('c', 'info');
+      debug('c', 'debug');
+      
+      expect(consoleSpy.error).toHaveBeenCalled();
+      expect(consoleSpy.warn).toHaveBeenCalled();
+      expect(consoleSpy.log).toHaveBeenCalled();
+      expect(consoleSpy.debug).not.toHaveBeenCalled();
+    });
+
+    it('sets log level to debug', () => {
+      setLogLevel('debug');
+      
+      error('c', 'error');
+      warn('c', 'warn');
+      info('c', 'info');
+      debug('c', 'debug');
+      
+      expect(consoleSpy.error).toHaveBeenCalled();
+      expect(consoleSpy.warn).toHaveBeenCalled();
+      expect(consoleSpy.log).toHaveBeenCalled();
+      expect(consoleSpy.debug).toHaveBeenCalled();
+    });
+
+    it('defaults to info for unknown level', () => {
+      // Set an invalid level via env (simulated by calling with valid level first)
+      setLogLevel('info');
+      
+      info('c', 'test');
+      debug('c', 'test');
+      
+      expect(consoleSpy.log).toHaveBeenCalled();
+      expect(consoleSpy.debug).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for previously untested core functionality:

### New Test Files

1. **src/utils/http.test.ts** (17 tests)
   - HTTP request success/failure handling
   - Timeout handling and classification
   - Retry logic for retryable errors
   - Rate limiting detection and state management
   - Different content-type handling

2. **src/utils/logger.test.ts** (16 tests)
   - Log level filtering (error, warn, info, debug)
   - Runtime log level configuration
   - Context prefixing

3. **src/utils/api-config.test.ts** (35 tests)
   - API endpoint URL building for Chatsvc, Calendar, CSA, Substrate
   - Custom baseUrl support for GCC/government clouds
   - Request header generation

4. **src/tools/registry.test.ts** (10 tests)
   - Tool definitions retrieval
   - Tool lookup by name
   - Tool invocation with validation
   - Error handling for unknown tools

### Test Results

- **Before:** 225 tests (7 test files)
- **After:** 303 tests (11 test files)
- **New tests added:** 78

All 303 tests pass.