### PR TITLE
fix: use numeric timestamp for clientMessageId instead of UUID

### DIFF
--- a/src/api/chatsvc-messaging.ts
+++ b/src/api/chatsvc-messaging.ts
@@ -147,7 +147,7 @@ export async function sendMessage(
   const { replyToMessageId } = options;
   const displayName = getUserDisplayName() || 'User';
 
-  const clientMessageId = crypto.randomUUID();
+  const clientMessageId = Date.now().toString();
 
   // Process content: handle mentions, links, and markdown formatting.
   // Always convert through markdown→HTML pipeline (never pass user content through


### PR DESCRIPTION
## Problem

The Teams internal chat API (chatsvc) rejects messages with a UUID as the `clientMessageId`, returning HTTP 400:

```
ClientMessageId must be a number in string format.
```

## Fix

Replace `crypto.randomUUID()` with `Date.now().toString()` in `sendMessage()`. The Teams API expects a numeric string (e.g. a millisecond timestamp), which is consistent with how the official Teams web client generates these IDs.

## Testing

Verified by sending messages (including with emoji) to a self-chat (`48:notes`) against a Microsoft 365 corporate tenant. Messages are delivered successfully after this change.

---

**Suggested label:** `bug`

_(Suggesting rather than applying: as an external fork contributor I don't have permission to set labels on this repo. Feel free to apply it on triage.)_