### PR TITLE
feat: add teams_create_meeting tool

### DIFF
--- a/src/api/calendar-api.ts
+++ b/src/api/calendar-api.ts
@@ -72,6 +72,46 @@ export interface CalendarViewResult {
   meetings: Meeting[];
 }
 
+/** An attendee for a meeting invite. */
+export interface MeetingAttendee {
+  /** Email address of the attendee. */
+  email: string;
+  /** Display name of the attendee (optional). */
+  name?: string;
+}
+
+/** Options for creating a new calendar event. */
+export interface CreateMeetingOptions {
+  /** Meeting subject/title. */
+  subject: string;
+  /** Start time (ISO 8601, e.g. "2026-06-05T10:00:00Z"). */
+  startTime: string;
+  /** End time (ISO 8601, e.g. "2026-06-05T10:30:00Z"). */
+  endTime: string;
+  /** Attendees to invite (email addresses). */
+  attendees?: MeetingAttendee[];
+  /** Meeting body/description text. */
+  body?: string;
+  /** Whether to create as a Teams online meeting (default: true). */
+  isOnlineMeeting?: boolean;
+  /** Physical or virtual location. */
+  location?: string;
+}
+
+/** Result from creating a calendar event. */
+export interface CreatedMeeting {
+  /** The newly created meeting's ID. */
+  id: string;
+  /** Meeting subject. */
+  subject: string;
+  /** Start time (ISO 8601). */
+  startTime: string;
+  /** End time (ISO 8601). */
+  endTime: string;
+  /** Teams join URL (if online meeting). */
+  joinUrl?: string;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
@@ -257,5 +297,94 @@ export async function getCalendarView(
   return ok({
     count: meetings.length,
     meetings,
+  });
+}
+
+/**
+ * Creates a new calendar event (meeting) in the user's Teams calendar.
+ *
+ * Uses the Teams mt/part API with the same Skype Spaces auth as getCalendarView.
+ * Optionally adds a Teams online meeting link and sends invites to attendees.
+ *
+ * @param options - Event creation options
+ * @returns The created meeting's ID, subject, times, and join URL
+ */
+export async function createMeeting(
+  options: CreateMeetingOptions
+): Promise<Result<CreatedMeeting>> {
+  const authResult = requireSkypeSpacesAuth();
+  if (!authResult.ok) {
+    return authResult;
+  }
+  const { skypeToken, spacesToken } = authResult.value;
+
+  const regionConfig = getRegionConfig();
+  if (!regionConfig) {
+    return err(createError(
+      ErrorCode.AUTH_REQUIRED,
+      'Could not determine region. Please run teams_login to authenticate.',
+      { suggestions: ['Call teams_login to authenticate'] }
+    ));
+  }
+
+  const body: Record<string, unknown> = {
+    subject: options.subject,
+    start: { dateTime: options.startTime, timeZone: 'UTC' },
+    end: { dateTime: options.endTime, timeZone: 'UTC' },
+    isOnlineMeeting: options.isOnlineMeeting !== false,
+    onlineMeetingProvider: 'teamsForBusiness',
+  };
+
+  if (options.attendees && options.attendees.length > 0) {
+    body.attendees = options.attendees.map((a) => ({
+      emailAddress: { address: a.email, name: a.name ?? a.email },
+      type: 'required',
+    }));
+  }
+
+  if (options.body) {
+    body.body = { contentType: 'text', content: options.body };
+  }
+
+  if (options.location) {
+    body.location = { displayName: options.location };
+  }
+
+  const createUrl = CALENDAR_API.createEvent(
+    regionConfig.regionPartition,
+    regionConfig.hasPartition,
+    regionConfig.teamsBaseUrl
+  );
+
+  const response = await httpRequest<Record<string, unknown>>(
+    createUrl,
+    {
+      method: 'POST',
+      headers: {
+        ...getTeamsHeaders(regionConfig.teamsBaseUrl),
+        'Authentication': `skypetoken=${skypeToken}`,
+        'Authorization': `Bearer ${spacesToken}`,
+      },
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!response.ok) {
+    return response;
+  }
+
+  const data = response.value.data as Record<string, unknown>;
+
+  // Extract the Teams join URL from the online meeting details
+  const onlineMeeting = data.onlineMeeting as Record<string, unknown> | undefined;
+  const joinUrl = (onlineMeeting?.joinUrl as string | undefined)
+    ?? (data.skypeTeamsMeetingUrl as string | undefined);
+
+  return ok({
+    id: data.id as string,
+    subject: (data.subject as string) ?? options.subject,
+    startTime: (data.start as Record<string, string>)?.dateTime ?? options.startTime,
+    endTime: (data.end as Record<string, string>)?.dateTime ?? options.endTime,
+    joinUrl,
   });
 }

--- a/src/tools/meeting-tools.ts
+++ b/src/tools/meeting-tools.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { RegisteredTool, ToolContext, ToolResult } from './index.js';
 import { handleApiResult } from './index.js';
-import { getCalendarView } from '../api/calendar-api.js';
+import { getCalendarView, createMeeting } from '../api/calendar-api.js';
 import { getTranscriptContent } from '../api/transcript-api.js';
 import {
   DEFAULT_MEETING_LIMIT,
@@ -26,6 +26,19 @@ export const GetMeetingsInputSchema = z.object({
 export const GetTranscriptInputSchema = z.object({
   threadId: z.string().min(1),
   meetingDate: z.string().optional(),
+});
+
+export const CreateMeetingInputSchema = z.object({
+  subject: z.string().min(1),
+  startTime: z.string().min(1),
+  endTime: z.string().min(1),
+  attendees: z.array(z.object({
+    email: z.string().email(),
+    name: z.string().optional(),
+  })).optional(),
+  body: z.string().optional(),
+  isOnlineMeeting: z.boolean().optional().default(true),
+  location: z.string().optional(),
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -76,6 +89,80 @@ async function handleGetMeetings(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Create Meeting Tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+const createMeetingToolDefinition: Tool = {
+  name: 'teams_create_meeting',
+  description: 'Create a new Teams calendar meeting and send invites to attendees. Returns the meeting ID, subject, start/end times, and the Teams join URL. Set isOnlineMeeting to true (default) to generate a Teams meeting link. Attendees receive calendar invites automatically.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      subject: {
+        type: 'string',
+        description: 'Meeting title/subject.',
+      },
+      startTime: {
+        type: 'string',
+        description: 'Start time in ISO 8601 format (e.g., "2026-06-05T10:00:00Z"). Use UTC.',
+      },
+      endTime: {
+        type: 'string',
+        description: 'End time in ISO 8601 format (e.g., "2026-06-05T10:30:00Z"). Use UTC.',
+      },
+      attendees: {
+        type: 'array',
+        description: 'List of attendees to invite.',
+        items: {
+          type: 'object',
+          properties: {
+            email: { type: 'string', description: 'Attendee email address.' },
+            name: { type: 'string', description: 'Attendee display name (optional).' },
+          },
+          required: ['email'],
+        },
+      },
+      body: {
+        type: 'string',
+        description: 'Meeting description or agenda (plain text).',
+      },
+      isOnlineMeeting: {
+        type: 'boolean',
+        description: 'Whether to generate a Teams meeting link (default: true).',
+      },
+      location: {
+        type: 'string',
+        description: 'Meeting location (room name or free text, optional).',
+      },
+    },
+    required: ['subject', 'startTime', 'endTime'],
+  },
+};
+
+async function handleCreateMeeting(
+  input: z.infer<typeof CreateMeetingInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  const result = await createMeeting({
+    subject: input.subject,
+    startTime: input.startTime,
+    endTime: input.endTime,
+    attendees: input.attendees,
+    body: input.body,
+    isOnlineMeeting: input.isOnlineMeeting,
+    location: input.location,
+  });
+
+  return handleApiResult(result, (value) => ({
+    id: value.id,
+    subject: value.subject,
+    startTime: value.startTime,
+    endTime: value.endTime,
+    joinUrl: value.joinUrl,
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Transcript Tool
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -122,6 +209,12 @@ export const getMeetingsTool: RegisteredTool<typeof GetMeetingsInputSchema> = {
   handler: handleGetMeetings,
 };
 
+export const createMeetingTool: RegisteredTool<typeof CreateMeetingInputSchema> = {
+  definition: createMeetingToolDefinition,
+  schema: CreateMeetingInputSchema,
+  handler: handleCreateMeeting,
+};
+
 export const getTranscriptTool: RegisteredTool<typeof GetTranscriptInputSchema> = {
   definition: getTranscriptToolDefinition,
   schema: GetTranscriptInputSchema,
@@ -129,4 +222,4 @@ export const getTranscriptTool: RegisteredTool<typeof GetTranscriptInputSchema> 
 };
 
 /** All meeting-related tools. */
-export const meetingTools = [getMeetingsTool, getTranscriptTool];
+export const meetingTools = [getMeetingsTool, createMeetingTool, getTranscriptTool];

--- a/src/utils/api-config.ts
+++ b/src/utils/api-config.ts
@@ -142,6 +142,18 @@ export const CALENDAR_API = {
     hasPartition
       ? `${baseUrl}/api/mt/part/${regionPartition}/v2.1/me/calendars/calendarView`
       : `${baseUrl}/api/mt/${regionPartition}/v2.1/me/calendars/calendarView`,
+
+  /**
+   * Create a new calendar event (meeting).
+   * 
+   * @param regionPartition - The full region-partition (e.g., "amer-02") or just region (e.g., "emea")
+   * @param hasPartition - Whether the tenant uses partitioned URLs
+   * @param baseUrl - Teams base URL (from config or default)
+   */
+  createEvent: (regionPartition: string, hasPartition: boolean, baseUrl = DEFAULT_TEAMS_BASE_URL) =>
+    hasPartition
+      ? `${baseUrl}/api/mt/part/${regionPartition}/v2.1/me/events`
+      : `${baseUrl}/api/mt/${regionPartition}/v2.1/me/events`,
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a `teams_create_meeting` tool that creates a Teams calendar event and sends invites to attendees.

### Changes

- **`src/utils/api-config.ts`** — adds `CALENDAR_API.createEvent` endpoint builder using the same `mt/part` partitioned-region pattern as `calendarView`
- **`src/api/calendar-api.ts`** — adds `createMeeting()` API function plus new types (`MeetingAttendee`, `CreateMeetingOptions`, `CreatedMeeting`); uses the same `requireSkypeSpacesAuth` tokens as `getCalendarView`
- **`src/tools/meeting-tools.ts`** — adds `teams_create_meeting` tool definition, Zod schema, handler, and exports it in `meetingTools`

### Tool inputs

| Field | Type | Required | Description |
|---|---|---|---|
| `subject` | string | yes | Meeting title |
| `startTime` | string | yes | ISO 8601 UTC start time |
| `endTime` | string | yes | ISO 8601 UTC end time |
| `attendees` | array | no | `{ email, name? }` objects |
| `body` | string | no | Meeting description or agenda |
| `isOnlineMeeting` | boolean | no | Defaults to `true`, generates a Teams join link |
| `location` | string | no | Room name or free text |

Returns: `{ id, subject, startTime, endTime, joinUrl? }`

### Approach

Uses `POST /api/mt/part/{region}/v2.1/me/events` (or non-partitioned equivalent), consistent with the project philosophy of using Teams internal APIs rather than Microsoft Graph. Auth uses `skypeToken` + `spacesToken` from `requireSkypeSpacesAuth()`, the same as `getCalendarView`.

### Testing

Builds clean with `npm run build` (zero TypeScript errors). Runtime validation against a live tenant is needed to confirm the exact endpoint path for event creation.
