### PR TITLE
feat: add Teams calendar management and presence tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The server uses your system's Chrome (macOS/Linux) or Edge (Windows) for authent
 | `teams_get_frequent_contacts` | Get frequently contacted people (useful for name resolution) |
 | `teams_get_chat` | Get conversation ID for 1:1 chat with a person |
 | `teams_create_group_chat` | Create a new group chat with multiple people (2+ others) |
+| `teams_get_presence` | Get real time presence (availability, activity, device, out of office) for one or more people |
 
 ### Organisation
 
@@ -128,6 +129,12 @@ The server uses your system's Chrome (macOS/Linux) or Edge (Windows) for authent
 | Tool | Description |
 |------|-------------|
 | `teams_get_meetings` | Get meetings from calendar (defaults to next 7 days) |
+| `teams_get_meeting` | Get full details of a single event by ID (attendees, body, location, join URL) |
+| `teams_create_meeting` | Create a calendar meeting and send invites (Teams join link by default) |
+| `teams_update_meeting` | Update or reschedule an existing event (only provided fields change) |
+| `teams_cancel_meeting` | Cancel an event (organiser notifies attendees; attendee removes from own calendar) |
+| `teams_respond_to_meeting` | Accept, tentatively accept, or decline a meeting invite |
+| `teams_get_schedule` | Check free/busy availability for one or more people over a time window |
 | `teams_get_transcript` | Get meeting transcript (requires `threadId` from `teams_get_meetings`) |
 
 `teams_get_meetings` returns: subject, times, organiser, join URL, `threadId` for meeting chat. Use `threadId` with `teams_get_thread` to read meeting chat, or with `teams_get_transcript` to get the full transcript with speakers and timestamps.

--- a/src/api/calendar-api.test.ts
+++ b/src/api/calendar-api.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for calendar-api helpers.
+ *
+ * Covers toUtcIso, which normalises Microsoft Graph dateTimeTimeZone values into
+ * unambiguous ISO 8601 strings (Graph omits the timezone marker on dateTime).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toUtcIso } from './calendar-api.js';
+
+describe('toUtcIso', () => {
+  it('appends Z to a UTC value that lacks a timezone marker', () => {
+    expect(toUtcIso({ dateTime: '2026-06-05T10:00:00.0000000', timeZone: 'UTC' }))
+      .toBe('2026-06-05T10:00:00.0000000Z');
+  });
+
+  it('appends Z when the timeZone field is missing (Graph defaults to UTC via Prefer)', () => {
+    expect(toUtcIso({ dateTime: '2026-06-05T10:00:00.0000000' }))
+      .toBe('2026-06-05T10:00:00.0000000Z');
+  });
+
+  it('treats timeZone casing leniently', () => {
+    expect(toUtcIso({ dateTime: '2026-06-05T10:00:00', timeZone: 'utc' }))
+      .toBe('2026-06-05T10:00:00Z');
+  });
+
+  it('leaves a value that already ends in Z untouched', () => {
+    expect(toUtcIso({ dateTime: '2026-06-05T10:00:00Z', timeZone: 'UTC' }))
+      .toBe('2026-06-05T10:00:00Z');
+  });
+
+  it('leaves a value with an explicit offset untouched', () => {
+    expect(toUtcIso({ dateTime: '2026-06-05T10:00:00+00:00' }))
+      .toBe('2026-06-05T10:00:00+00:00');
+    expect(toUtcIso({ dateTime: '2026-06-05T15:30:00+05:30' }))
+      .toBe('2026-06-05T15:30:00+05:30');
+  });
+
+  it('does not append Z for a non-UTC timezone (avoids mislabelling)', () => {
+    expect(toUtcIso({ dateTime: '2026-06-05T10:00:00', timeZone: 'Pacific Standard Time' }))
+      .toBe('2026-06-05T10:00:00');
+  });
+
+  it('returns an empty string for missing input', () => {
+    expect(toUtcIso(undefined)).toBe('');
+    expect(toUtcIso({})).toBe('');
+  });
+});

--- a/src/api/calendar-api.ts
+++ b/src/api/calendar-api.ts
@@ -199,6 +199,30 @@ export interface GetScheduleResult {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * Graph `Prefer` header that asks for all event times to be returned in UTC.
+ * Combined with {@link toUtcIso}, this guarantees unambiguous ISO 8601 output.
+ */
+const GRAPH_UTC_PREFER = 'outlook.timezone="UTC"';
+
+/**
+ * Normalises a Graph `dateTimeTimeZone` value to an unambiguous ISO 8601 string.
+ *
+ * Graph returns `dateTime` without any timezone marker (e.g.
+ * "2026-06-05T10:00:00.0000000") alongside a separate `timeZone` field. When the
+ * times are UTC (which we force via the `Prefer: outlook.timezone="UTC"` header),
+ * we append a `Z` so consumers don't misread them as local time.
+ */
+export function toUtcIso(dt?: { dateTime?: string; timeZone?: string }): string {
+  const raw = dt?.dateTime;
+  if (!raw) return '';
+  // Already carries an offset or Z.
+  if (/([zZ]|[+-]\d{2}:?\d{2})$/.test(raw)) return raw;
+  // Mark UTC times as such; leave non-UTC values untouched.
+  if (!dt?.timeZone || dt.timeZone.toUpperCase() === 'UTC') return `${raw}Z`;
+  return raw;
+}
+
+/**
  * Parses a raw API meeting response into our Meeting type.
  */
 function parseMeeting(raw: Record<string, unknown>): Meeting {
@@ -269,8 +293,8 @@ function parseGraphEvent(raw: Record<string, unknown>): Meeting {
   const organizer = raw.organizer as { emailAddress?: { name?: string; address?: string } } | undefined;
   const location = raw.location as { displayName?: string } | undefined;
   const onlineMeeting = raw.onlineMeeting as { joinUrl?: string } | undefined;
-  const start = raw.start as { dateTime?: string } | undefined;
-  const end = raw.end as { dateTime?: string } | undefined;
+  const start = raw.start as { dateTime?: string; timeZone?: string } | undefined;
+  const end = raw.end as { dateTime?: string; timeZone?: string } | undefined;
   const responseStatus = raw.responseStatus as { response?: string } | undefined;
 
   // Map Graph responseStatus to our enum
@@ -299,8 +323,8 @@ function parseGraphEvent(raw: Record<string, unknown>): Meeting {
   return {
     id: raw.id as string,
     subject: (raw.subject as string) || '(No subject)',
-    startTime: start?.dateTime ?? '',
-    endTime: end?.dateTime ?? '',
+    startTime: toUtcIso(start),
+    endTime: toUtcIso(end),
     organizer: {
       name: organizer?.emailAddress?.name ?? 'Unknown',
       email: organizer?.emailAddress?.address ?? '',
@@ -491,7 +515,7 @@ export async function createMeeting(
     GRAPH_CALENDAR_API.events(),
     {
       method: 'POST',
-      headers: getGraphHeaders(graphToken),
+      headers: { ...getGraphHeaders(graphToken), 'Prefer': GRAPH_UTC_PREFER },
       body: JSON.stringify(body),
     }
   );
@@ -507,8 +531,8 @@ export async function createMeeting(
   return ok({
     id: data.id as string,
     subject: (data.subject as string) ?? options.subject,
-    startTime: (data.start as Record<string, string>)?.dateTime ?? options.startTime,
-    endTime: (data.end as Record<string, string>)?.dateTime ?? options.endTime,
+    startTime: toUtcIso(data.start as { dateTime?: string; timeZone?: string }) || options.startTime,
+    endTime: toUtcIso(data.end as { dateTime?: string; timeZone?: string }) || options.endTime,
     joinUrl,
   });
 }
@@ -531,7 +555,7 @@ export async function getMeeting(eventId: string): Promise<Result<Meeting>> {
     GRAPH_CALENDAR_API.event(eventId),
     {
       method: 'GET',
-      headers: getGraphHeaders(graphToken),
+      headers: { ...getGraphHeaders(graphToken), 'Prefer': GRAPH_UTC_PREFER },
     }
   );
 
@@ -567,7 +591,7 @@ export async function updateMeeting(
     GRAPH_CALENDAR_API.event(eventId),
     {
       method: 'PATCH',
-      headers: getGraphHeaders(graphToken),
+      headers: { ...getGraphHeaders(graphToken), 'Prefer': GRAPH_UTC_PREFER },
       body: JSON.stringify(body),
     }
   );
@@ -634,7 +658,8 @@ export async function respondToMeeting(
     body.comment = options.comment;
   }
 
-  if (options.response === 'decline' && options.proposedNewTime) {
+  // Graph accepts a proposed new time on decline and tentativelyAccept, but not accept.
+  if (options.proposedNewTime && options.response !== 'accept') {
     body.proposedNewTime = {
       start: { dateTime: options.proposedNewTime.start, timeZone: 'UTC' },
       end: { dateTime: options.proposedNewTime.end, timeZone: 'UTC' },
@@ -683,7 +708,7 @@ export async function getSchedule(
     GRAPH_CALENDAR_API.getSchedule(),
     {
       method: 'POST',
-      headers: getGraphHeaders(graphToken),
+      headers: { ...getGraphHeaders(graphToken), 'Prefer': GRAPH_UTC_PREFER },
       body: JSON.stringify(body),
     }
   );
@@ -699,8 +724,8 @@ export async function getSchedule(
       scheduleId: raw.scheduleId as string,
       availabilityView: (raw.availabilityView as string) ?? '',
       scheduleItems: rawItems.map((item) => ({
-        start: ((item.start as Record<string, string>)?.dateTime) ?? '',
-        end: ((item.end as Record<string, string>)?.dateTime) ?? '',
+        start: toUtcIso(item.start as { dateTime?: string; timeZone?: string }),
+        end: toUtcIso(item.end as { dateTime?: string; timeZone?: string }),
         status: (item.status as ScheduleItem['status']) ?? 'unknown',
         subject: item.subject as string | undefined,
         isPrivate: item.isPrivate as boolean | undefined,

--- a/src/api/calendar-api.ts
+++ b/src/api/calendar-api.ts
@@ -5,10 +5,15 @@
  */
 
 import { httpRequest } from '../utils/http.js';
-import { CALENDAR_API, getTeamsHeaders } from '../utils/api-config.js';
+import {
+  CALENDAR_API,
+  GRAPH_CALENDAR_API,
+  getTeamsHeaders,
+  getGraphHeaders,
+} from '../utils/api-config.js';
 import { type Result, ok, err } from '../types/result.js';
 import { ErrorCode, createError } from '../types/errors.js';
-import { requireSkypeSpacesAuth, getRegionConfig } from '../utils/auth-guards.js';
+import { requireSkypeSpacesAuth, requireGraphAuth, getRegionConfig } from '../utils/auth-guards.js';
 import {
   DEFAULT_MEETING_LIMIT,
   DEFAULT_MEETING_DAYS_AHEAD,
@@ -44,6 +49,8 @@ export interface Meeting {
   joinUrl?: string;
   /** Meeting chat thread ID (for use with teams_get_thread). */
   threadId?: string;
+  /** URL used to update or remove the Teams scheduling service entry for this meeting. */
+  schedulingServiceUpdateUrl?: string;
   /** Your RSVP status. */
   myResponse: 'None' | 'Accepted' | 'Tentative' | 'Declined';
   /** Calendar show-as status. */
@@ -70,6 +77,121 @@ export interface CalendarViewResult {
   count: number;
   /** List of meetings. */
   meetings: Meeting[];
+}
+
+/** An attendee for a meeting invite. */
+export interface MeetingAttendee {
+  /** Email address of the attendee. */
+  email: string;
+  /** Display name of the attendee (optional). */
+  name?: string;
+}
+
+/** Options for creating a new calendar event. */
+export interface CreateMeetingOptions {
+  /** Meeting subject/title. */
+  subject: string;
+  /** Start time (ISO 8601, e.g. "2026-06-05T10:00:00Z"). */
+  startTime: string;
+  /** End time (ISO 8601, e.g. "2026-06-05T10:30:00Z"). */
+  endTime: string;
+  /** Attendees to invite (email addresses). */
+  attendees?: MeetingAttendee[];
+  /** Meeting body/description text. */
+  body?: string;
+  /** Whether to create as a Teams online meeting (default: true). */
+  isOnlineMeeting?: boolean;
+  /** Physical or virtual location. */
+  location?: string;
+}
+
+/** Result from creating a calendar event. */
+export interface CreatedMeeting {
+  /** The newly created meeting's ID. */
+  id: string;
+  /** Meeting subject. */
+  subject: string;
+  /** Start time (ISO 8601). */
+  startTime: string;
+  /** End time (ISO 8601). */
+  endTime: string;
+  /** Teams join URL (if online meeting). */
+  joinUrl?: string;
+}
+
+/** Options for updating an existing calendar event. All fields are optional. */
+export type UpdateMeetingOptions = Partial<Omit<CreateMeetingOptions, 'isOnlineMeeting'>>;
+
+/** RSVP response type. */
+export type MeetingResponse = 'accept' | 'tentativelyAccept' | 'decline';
+
+/** Options for responding to a meeting invite. */
+export interface RespondToMeetingOptions {
+  /** Your response. */
+  response: MeetingResponse;
+  /** Optional message to include with your response. */
+  comment?: string;
+  /**
+   * Whether to send a response email to the organiser (default: true).
+   * Set to false to silently update your calendar without notifying the organiser.
+   */
+  sendResponse?: boolean;
+  /**
+   * For decline only — propose an alternative time.
+   * Only valid when response is "decline" and the event allows new time proposals.
+   */
+  proposedNewTime?: {
+    start: string; // ISO 8601
+    end: string;   // ISO 8601
+  };
+}
+
+/** A single free/busy slot for a user. */
+export interface ScheduleItem {
+  /** Start of the busy slot (ISO 8601). */
+  start: string;
+  /** End of the busy slot (ISO 8601). */
+  end: string;
+  /** Free/busy status for this slot. */
+  status: 'free' | 'busy' | 'tentative' | 'oof' | 'workingElsewhere' | 'unknown';
+  /** Subject of the event (may be empty for privacy). */
+  subject?: string;
+  /** Whether the event is private. */
+  isPrivate?: boolean;
+}
+
+/** Free/busy schedule for a single user. */
+export interface UserSchedule {
+  /** The email address / identity this schedule belongs to. */
+  scheduleId: string;
+  /**
+   * String encoding of availability in the requested window.
+   * Each character represents one interval (default 30 min):
+   * 0=free, 1=tentative, 2=busy, 3=OOF, 4=working elsewhere
+   */
+  availabilityView: string;
+  /** Individual busy slots within the requested window. */
+  scheduleItems: ScheduleItem[];
+}
+
+/** Options for fetching free/busy schedules. */
+export interface GetScheduleOptions {
+  /** Email addresses of people whose availability to check. */
+  schedules: string[];
+  /** Start of the window to check (ISO 8601). */
+  startTime: string;
+  /** End of the window to check (ISO 8601). */
+  endTime: string;
+  /**
+   * Duration of each slot in the availabilityView string, in minutes.
+   * Default: 30. Min: 5. Max: 1440.
+   */
+  availabilityViewInterval?: number;
+}
+
+/** Result from getSchedule. */
+export interface GetScheduleResult {
+  schedules: UserSchedule[];
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -129,11 +251,93 @@ function parseMeeting(raw: Record<string, unknown>): Meeting {
     isOnlineMeeting: raw.isOnlineMeeting === true,
     joinUrl: raw.skypeTeamsMeetingUrl as string | undefined,
     threadId,
+    schedulingServiceUpdateUrl: raw.schedulingServiceUpdateUrl as string | undefined,
     myResponse,
     showAs,
     isOrganizer: raw.isOrganizer === true,
     eventType: (raw.eventType as string) || 'Single',
   };
+}
+
+/**
+ * Parses a raw Microsoft Graph event into our Meeting type.
+ *
+ * Graph returns a different shape than the mt/part calendarView, so this maps
+ * the Graph fields onto the same Meeting interface for consistency.
+ */
+function parseGraphEvent(raw: Record<string, unknown>): Meeting {
+  const organizer = raw.organizer as { emailAddress?: { name?: string; address?: string } } | undefined;
+  const location = raw.location as { displayName?: string } | undefined;
+  const onlineMeeting = raw.onlineMeeting as { joinUrl?: string } | undefined;
+  const start = raw.start as { dateTime?: string } | undefined;
+  const end = raw.end as { dateTime?: string } | undefined;
+  const responseStatus = raw.responseStatus as { response?: string } | undefined;
+
+  // Map Graph responseStatus to our enum
+  let myResponse: Meeting['myResponse'] = 'None';
+  switch (responseStatus?.response) {
+    case 'organizer':
+    case 'accepted':
+      myResponse = 'Accepted';
+      break;
+    case 'tentativelyAccepted':
+      myResponse = 'Tentative';
+      break;
+    case 'declined':
+      myResponse = 'Declined';
+      break;
+  }
+
+  // Map Graph showAs to our enum
+  const rawShowAs = raw.showAs as string | undefined;
+  let showAs: Meeting['showAs'] = 'Unknown';
+  if (rawShowAs === 'free') showAs = 'Free';
+  else if (rawShowAs === 'busy') showAs = 'Busy';
+  else if (rawShowAs === 'tentative') showAs = 'Tentative';
+  else if (rawShowAs === 'oof' || rawShowAs === 'workingElsewhere') showAs = 'OutOfOffice';
+
+  return {
+    id: raw.id as string,
+    subject: (raw.subject as string) || '(No subject)',
+    startTime: start?.dateTime ?? '',
+    endTime: end?.dateTime ?? '',
+    organizer: {
+      name: organizer?.emailAddress?.name ?? 'Unknown',
+      email: organizer?.emailAddress?.address ?? '',
+    },
+    location: location?.displayName,
+    isOnlineMeeting: raw.isOnlineMeeting === true,
+    joinUrl: onlineMeeting?.joinUrl,
+    threadId: undefined,
+    schedulingServiceUpdateUrl: undefined,
+    myResponse,
+    showAs,
+    isOrganizer: raw.isOrganizer === true,
+    eventType: (raw.type as string) || 'singleInstance',
+  };
+}
+
+/**
+ * Builds a Graph event request body from create/update options.
+ */
+function buildGraphEventBody(options: Partial<CreateMeetingOptions>): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (options.subject !== undefined) body.subject = options.subject;
+  if (options.startTime !== undefined) body.start = { dateTime: options.startTime, timeZone: 'UTC' };
+  if (options.endTime !== undefined) body.end = { dateTime: options.endTime, timeZone: 'UTC' };
+  if (options.body !== undefined) body.body = { contentType: 'text', content: options.body };
+  if (options.location !== undefined) body.location = { displayName: options.location };
+  if (options.attendees !== undefined) {
+    body.attendees = options.attendees.map((a) => ({
+      emailAddress: { address: a.email, name: a.name ?? a.email },
+      type: 'required',
+    }));
+  }
+  if (options.isOnlineMeeting !== undefined) {
+    body.isOnlineMeeting = options.isOnlineMeeting;
+    if (options.isOnlineMeeting) body.onlineMeetingProvider = 'teamsForBusiness';
+  }
+  return body;
 }
 
 /**
@@ -258,4 +462,251 @@ export async function getCalendarView(
     count: meetings.length,
     meetings,
   });
+}
+
+/**
+ * Creates a new calendar event (meeting) in the user's Teams calendar.
+ *
+ * Uses the Microsoft Graph API (POST /me/events) with a Graph token.
+ * Optionally adds a Teams online meeting link and sends invites to attendees.
+ *
+ * @param options - Event creation options
+ * @returns The created meeting's ID, subject, times, and join URL
+ */
+export async function createMeeting(
+  options: CreateMeetingOptions
+): Promise<Result<CreatedMeeting>> {
+  const authResult = requireGraphAuth();
+  if (!authResult.ok) {
+    return authResult;
+  }
+  const graphToken = authResult.value;
+
+  const body = buildGraphEventBody({
+    ...options,
+    isOnlineMeeting: options.isOnlineMeeting !== false,
+  });
+
+  const response = await httpRequest<Record<string, unknown>>(
+    GRAPH_CALENDAR_API.events(),
+    {
+      method: 'POST',
+      headers: getGraphHeaders(graphToken),
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!response.ok) {
+    return response;
+  }
+
+  const data = response.value.data as Record<string, unknown>;
+  const onlineMeeting = data.onlineMeeting as Record<string, unknown> | undefined;
+  const joinUrl = onlineMeeting?.joinUrl as string | undefined;
+
+  return ok({
+    id: data.id as string,
+    subject: (data.subject as string) ?? options.subject,
+    startTime: (data.start as Record<string, string>)?.dateTime ?? options.startTime,
+    endTime: (data.end as Record<string, string>)?.dateTime ?? options.endTime,
+    joinUrl,
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Get single meeting
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Gets a single calendar event by its ID.
+ *
+ * @param eventId - The event ID (meeting.id from getCalendarView or createMeeting)
+ */
+export async function getMeeting(eventId: string): Promise<Result<Meeting>> {
+  const authResult = requireGraphAuth();
+  if (!authResult.ok) return authResult;
+  const graphToken = authResult.value;
+
+  const response = await httpRequest<Record<string, unknown>>(
+    GRAPH_CALENDAR_API.event(eventId),
+    {
+      method: 'GET',
+      headers: getGraphHeaders(graphToken),
+    }
+  );
+
+  if (!response.ok) return response;
+
+  const raw = response.value.data as Record<string, unknown>;
+  return ok(parseGraphEvent(raw));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Update meeting
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Updates an existing calendar event.
+ *
+ * Only the fields you provide are changed (PATCH semantics).
+ *
+ * @param eventId - The event ID to update
+ * @param options - Fields to change
+ */
+export async function updateMeeting(
+  eventId: string,
+  options: UpdateMeetingOptions
+): Promise<Result<Meeting>> {
+  const authResult = requireGraphAuth();
+  if (!authResult.ok) return authResult;
+  const graphToken = authResult.value;
+
+  const body = buildGraphEventBody(options);
+
+  const response = await httpRequest<Record<string, unknown>>(
+    GRAPH_CALENDAR_API.event(eventId),
+    {
+      method: 'PATCH',
+      headers: getGraphHeaders(graphToken),
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!response.ok) return response;
+
+  const raw = response.value.data as Record<string, unknown>;
+  return ok(parseGraphEvent(raw));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cancel / delete meeting
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Cancels or removes a calendar event.
+ *
+ * If you are the organiser, this sends a cancellation to all attendees.
+ * If you are an attendee, this removes the event from your calendar only.
+ *
+ * @param eventId - The event ID to cancel/remove
+ */
+export async function cancelMeeting(eventId: string): Promise<Result<void>> {
+  const authResult = requireGraphAuth();
+  if (!authResult.ok) return authResult;
+  const graphToken = authResult.value;
+
+  const response = await httpRequest<void>(
+    GRAPH_CALENDAR_API.event(eventId),
+    {
+      method: 'DELETE',
+      headers: getGraphHeaders(graphToken),
+    }
+  );
+
+  if (!response.ok) return response;
+  return ok(undefined);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RSVP — respond to a meeting invite
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Accepts, tentatively accepts, or declines a meeting invite.
+ *
+ * @param eventId - The event ID to respond to
+ * @param options - Response type, optional comment, and optional proposed new time
+ */
+export async function respondToMeeting(
+  eventId: string,
+  options: RespondToMeetingOptions
+): Promise<Result<void>> {
+  const authResult = requireGraphAuth();
+  if (!authResult.ok) return authResult;
+  const graphToken = authResult.value;
+
+  const sendResponse = options.sendResponse !== false;
+  const body: Record<string, unknown> = { sendResponse };
+
+  // Graph rejects a non-null comment when sendResponse is false, so only
+  // include a comment when one was actually provided and we are responding.
+  if (options.comment && sendResponse) {
+    body.comment = options.comment;
+  }
+
+  if (options.response === 'decline' && options.proposedNewTime) {
+    body.proposedNewTime = {
+      start: { dateTime: options.proposedNewTime.start, timeZone: 'UTC' },
+      end: { dateTime: options.proposedNewTime.end, timeZone: 'UTC' },
+    };
+  }
+
+  const response = await httpRequest<void>(
+    GRAPH_CALENDAR_API.respondToEvent(eventId, options.response),
+    {
+      method: 'POST',
+      headers: getGraphHeaders(graphToken),
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!response.ok) return response;
+  return ok(undefined);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Free/busy schedule
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Gets the free/busy availability schedule for one or more users.
+ *
+ * Useful for checking whether attendees are available before scheduling a meeting.
+ *
+ * @param options - List of email addresses and time window to check
+ */
+export async function getSchedule(
+  options: GetScheduleOptions
+): Promise<Result<GetScheduleResult>> {
+  const authResult = requireGraphAuth();
+  if (!authResult.ok) return authResult;
+  const graphToken = authResult.value;
+
+  const body = {
+    schedules: options.schedules,
+    startTime: { dateTime: options.startTime, timeZone: 'UTC' },
+    endTime: { dateTime: options.endTime, timeZone: 'UTC' },
+    availabilityViewInterval: options.availabilityViewInterval ?? 30,
+  };
+
+  const response = await httpRequest<Record<string, unknown>>(
+    GRAPH_CALENDAR_API.getSchedule(),
+    {
+      method: 'POST',
+      headers: getGraphHeaders(graphToken),
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!response.ok) return response;
+
+  const data = response.value.data as Record<string, unknown>;
+  const rawSchedules = (data.value ?? []) as Array<Record<string, unknown>>;
+
+  const schedules: UserSchedule[] = rawSchedules.map((raw) => {
+    const rawItems = (raw.scheduleItems ?? []) as Array<Record<string, unknown>>;
+    return {
+      scheduleId: raw.scheduleId as string,
+      availabilityView: (raw.availabilityView as string) ?? '',
+      scheduleItems: rawItems.map((item) => ({
+        start: ((item.start as Record<string, string>)?.dateTime) ?? '',
+        end: ((item.end as Record<string, string>)?.dateTime) ?? '',
+        status: (item.status as ScheduleItem['status']) ?? 'unknown',
+        subject: item.subject as string | undefined,
+        isPrivate: item.isPrivate as boolean | undefined,
+      })),
+    };
+  });
+
+  return ok({ schedules });
 }

--- a/src/api/presence-api.ts
+++ b/src/api/presence-api.ts
@@ -1,0 +1,132 @@
+/**
+ * Presence API client.
+ *
+ * Fetches availability/activity, out of office state, and auto reply notes for
+ * one or more users from the Teams User Presence Service (UPS).
+ */
+
+import { httpRequest } from '../utils/http.js';
+import { PRESENCE_API, getBearerHeaders } from '../utils/api-config.js';
+import { type Result, ok, err } from '../types/result.js';
+import { ErrorCode, createError } from '../types/errors.js';
+import { requireSkypeSpacesAuth, getRegionConfig } from '../utils/auth-guards.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Presence and out of office information for a single user. */
+export interface UserPresence {
+  /** The user's MRI (e.g. "8:orgid:<guid>"). */
+  id: string;
+  /** Availability status (e.g. Available, Busy, Away, Offline, DoNotDisturb). */
+  availability: string;
+  /** Fine grained activity (e.g. Available, InACall, InAMeeting, Presenting, Offline). */
+  activity: string;
+  /** Device the user is active on (e.g. Web, Mobile, Desktop), if known. */
+  deviceType?: string;
+  /** Last time the user was active (ISO 8601), if known. */
+  lastActiveTime?: string;
+  /** Whether the user is currently out of office per their calendar. */
+  isOutOfOffice: boolean;
+  /** The user's out of office / auto reply note, if set. */
+  outOfOfficeMessage?: string;
+  /** When the out of office note expires (ISO 8601), if set. */
+  outOfOfficeExpiry?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalises a user identifier to an MRI.
+ *
+ * Accepts an MRI ("8:orgid:<guid>"), an object id with tenant ("<guid>@<tenant>"),
+ * or a raw object id ("<guid>"), and returns the MRI form used by the presence API.
+ */
+function toMri(userId: string): string {
+  if (userId.startsWith('8:') || userId.startsWith('28:')) {
+    return userId;
+  }
+  const guid = userId.includes('@') ? userId.split('@')[0] : userId;
+  return `8:orgid:${guid}`;
+}
+
+/**
+ * Parses a raw UPS presence entry into our UserPresence type.
+ */
+function parsePresence(raw: Record<string, unknown>): UserPresence {
+  const presence = (raw.presence ?? {}) as Record<string, unknown>;
+  const calendarData = (presence.calendarData ?? {}) as Record<string, unknown>;
+  const oofNote = calendarData.outOfOfficeNote as
+    | { message?: string; expiry?: string }
+    | undefined;
+
+  const message = oofNote?.message?.trim();
+
+  return {
+    id: raw.mri as string,
+    availability: (presence.availability as string) ?? 'Unknown',
+    activity: (presence.activity as string) ?? 'Unknown',
+    deviceType: presence.deviceType as string | undefined,
+    lastActiveTime: presence.lastActiveTime as string | undefined,
+    isOutOfOffice: calendarData.isOutOfOffice === true,
+    outOfOfficeMessage: message ? message : undefined,
+    outOfOfficeExpiry: oofNote?.expiry,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// API Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Gets presence (and out of office / auto reply notes) for one or more users.
+ *
+ * @param userIds - User MRIs, object ids with tenant, or raw object ids
+ * @returns Presence information for each requested user
+ */
+export async function getPresence(
+  userIds: string[]
+): Promise<Result<UserPresence[]>> {
+  const authResult = requireSkypeSpacesAuth();
+  if (!authResult.ok) {
+    return authResult;
+  }
+  const { spacesToken } = authResult.value;
+
+  const regionConfig = getRegionConfig();
+  if (!regionConfig) {
+    return err(createError(
+      ErrorCode.AUTH_REQUIRED,
+      'Could not determine region. Please run teams_login to authenticate.',
+      { suggestions: ['Call teams_login to authenticate'] }
+    ));
+  }
+
+  const body = userIds.map((id) => ({ mri: toMri(id), source: 'ups' }));
+
+  // The presence (ups) service uses the geo region (e.g. "emea"), which is the
+  // prefix of the partitioned region ("emea-02"), not the chatsvc country code.
+  const geoRegion = regionConfig.regionPartition.split('-')[0];
+  const url = PRESENCE_API.getPresence(geoRegion, regionConfig.teamsBaseUrl);
+
+  const response = await httpRequest<Array<Record<string, unknown>>>(
+    url,
+    {
+      method: 'POST',
+      headers: getBearerHeaders(spacesToken, regionConfig.teamsBaseUrl),
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!response.ok) {
+    return response;
+  }
+
+  const data = response.value.data;
+  const entries = Array.isArray(data) ? data : [];
+
+  return ok(entries.map(parsePresence));
+}

--- a/src/auth/token-extractor.test.ts
+++ b/src/auth/token-extractor.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for token-extractor helpers.
+ *
+ * Covers jwtGrantsScope, used to ensure a Graph token actually carries the
+ * Calendars.ReadWrite scope before it is used for calendar operations.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { jwtGrantsScope } from './token-extractor.js';
+
+describe('jwtGrantsScope', () => {
+  it('returns true when a delegated scope is present in scp', () => {
+    const payload = { scp: 'Calendars.Read Calendars.ReadWrite Mail.Read' };
+    expect(jwtGrantsScope(payload, 'Calendars.ReadWrite')).toBe(true);
+  });
+
+  it('returns false when the scope is absent from scp', () => {
+    const payload = { scp: 'Calendars.Read Mail.Read' };
+    expect(jwtGrantsScope(payload, 'Calendars.ReadWrite')).toBe(false);
+  });
+
+  it('matches scopes case-insensitively', () => {
+    const payload = { scp: 'calendars.readwrite' };
+    expect(jwtGrantsScope(payload, 'Calendars.ReadWrite')).toBe(true);
+  });
+
+  it('checks app roles when scp is absent', () => {
+    const payload = { roles: ['Calendars.ReadWrite', 'Mail.Read'] };
+    expect(jwtGrantsScope(payload, 'Calendars.ReadWrite')).toBe(true);
+    expect(jwtGrantsScope(payload, 'User.Read.All')).toBe(false);
+  });
+
+  it('returns null when scopes cannot be determined', () => {
+    expect(jwtGrantsScope({ aud: 'https://graph.microsoft.com' }, 'Calendars.ReadWrite')).toBeNull();
+    expect(jwtGrantsScope(null, 'Calendars.ReadWrite')).toBeNull();
+  });
+});

--- a/src/auth/token-extractor.ts
+++ b/src/auth/token-extractor.ts
@@ -51,6 +51,26 @@ function isJwtToken(value: unknown): value is string {
   return typeof value === 'string' && value.startsWith('ey');
 }
 
+/**
+ * Checks whether a decoded JWT payload grants a given delegated/app scope.
+ *
+ * Returns `null` when the token's scopes can't be determined (no `scp`/`roles`
+ * claim), so callers can decide whether to be lenient rather than wrongly
+ * rejecting a token.
+ */
+export function jwtGrantsScope(
+  payload: Record<string, unknown> | null,
+  scope: string
+): boolean | null {
+  if (!payload) return null;
+  const scp = typeof payload.scp === 'string' ? payload.scp.split(' ') : null;
+  const roles = Array.isArray(payload.roles) ? (payload.roles as string[]) : null;
+  const granted = scp ?? roles;
+  if (!granted) return null;
+  const target = scope.toLowerCase();
+  return granted.some((s) => s.toLowerCase() === target);
+}
+
 // ============================================================================
 // Session Helpers
 // ============================================================================
@@ -325,7 +345,11 @@ export function extractSkypeSpacesToken(state?: SessionState): string | null {
  *
  * This token is required for calendar write operations (create/update/cancel/RSVP)
  * and free/busy lookups, which Teams performs via graph.microsoft.com rather than
- * the mt/part middle-tier API. The token carries Calendars.ReadWrite scope.
+ * the mt/part middle-tier API. The token must carry the Calendars.ReadWrite scope.
+ *
+ * Teams caches several graph.microsoft.com tokens with different scope sets; we
+ * deliberately skip any whose scopes are known to lack Calendars.ReadWrite so
+ * calendar calls fail fast with a clear auth error instead of a confusing 403.
  */
 export function extractGraphToken(state?: SessionState): string | null {
   return withLocalStorage(state, (localStorage) => {
@@ -336,7 +360,7 @@ export function extractGraphToken(state?: SessionState): string | null {
         const entry = JSON.parse(item.value);
         if (!entry.target || !isJwtToken(entry.secret)) continue;
 
-        // Look for a graph.microsoft.com token (any scope set including Calendars)
+        // Look for a graph.microsoft.com token.
         if (!entry.target.includes('graph.microsoft.com')) continue;
 
         const payload = decodeJwtPayload(entry.secret);
@@ -344,10 +368,14 @@ export function extractGraphToken(state?: SessionState): string | null {
 
         const expiry = new Date(payload.exp * 1000);
 
-        // Skip expired tokens
+        // Skip expired tokens.
         if (expiry.getTime() <= Date.now()) continue;
 
-        // Keep the one with the latest expiry
+        // Skip tokens that explicitly lack calendar write access. When the
+        // scopes can't be determined (null) we stay lenient and accept it.
+        if (jwtGrantsScope(payload, 'Calendars.ReadWrite') === false) continue;
+
+        // Keep the one with the latest expiry.
         if (!bestCandidate || expiry > bestCandidate.expiry) {
           bestCandidate = { token: entry.secret, expiry };
         }

--- a/src/auth/token-extractor.ts
+++ b/src/auth/token-extractor.ts
@@ -320,6 +320,46 @@ export function extractSkypeSpacesToken(state?: SessionState): string | null {
   });
 }
 
+/**
+ * Extracts a Microsoft Graph API token from session state.
+ *
+ * This token is required for calendar write operations (create/update/cancel/RSVP)
+ * and free/busy lookups, which Teams performs via graph.microsoft.com rather than
+ * the mt/part middle-tier API. The token carries Calendars.ReadWrite scope.
+ */
+export function extractGraphToken(state?: SessionState): string | null {
+  return withLocalStorage(state, (localStorage) => {
+    let bestCandidate: { token: string; expiry: Date } | null = null;
+
+    for (const item of localStorage) {
+      try {
+        const entry = JSON.parse(item.value);
+        if (!entry.target || !isJwtToken(entry.secret)) continue;
+
+        // Look for a graph.microsoft.com token (any scope set including Calendars)
+        if (!entry.target.includes('graph.microsoft.com')) continue;
+
+        const payload = decodeJwtPayload(entry.secret);
+        if (!payload?.exp || typeof payload.exp !== 'number') continue;
+
+        const expiry = new Date(payload.exp * 1000);
+
+        // Skip expired tokens
+        if (expiry.getTime() <= Date.now()) continue;
+
+        // Keep the one with the latest expiry
+        if (!bestCandidate || expiry > bestCandidate.expiry) {
+          bestCandidate = { token: entry.secret, expiry };
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return bestCandidate?.token ?? null;
+  });
+}
+
 /** Region configuration from Teams discovery. */
 export interface RegionConfig {
   /** Base region (e.g., "amer", "emea", "apac") - used by chatsvc, csa APIs. */

--- a/src/auth/token-refresh-http.test.ts
+++ b/src/auth/token-refresh-http.test.ts
@@ -210,7 +210,7 @@ describe('refreshTokensViaHttp', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value.tokensRefreshed).toBe(3);
+      expect(result.value.tokensRefreshed).toBe(4);
       expect(result.value.skypeTokenRefreshed).toBe(true);
       expect(result.value.refreshTokenRotated).toBe(true);
     }
@@ -221,8 +221,8 @@ describe('refreshTokensViaHttp', () => {
     // Verify token cache was cleared
     expect(clearTokenCache).toHaveBeenCalledOnce();
 
-    // Verify fetch was called 4 times (3 token refreshes + 1 skype exchange)
-    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(4);
+    // Verify fetch was called 5 times (4 token refreshes + 1 skype exchange)
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(5);
   });
 
   it('updates skypetoken_asm cookies in session state', async () => {
@@ -313,8 +313,8 @@ describe('refreshTokensViaHttp', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      // 2 of 3 scopes succeeded (first one failed with network error)
-      expect(result.value.tokensRefreshed).toBe(2);
+      // 3 of 4 scopes succeeded (first one failed with network error)
+      expect(result.value.tokensRefreshed).toBe(3);
     }
   });
 
@@ -341,7 +341,7 @@ describe('refreshTokensViaHttp', () => {
     // Should still succeed — skype token failure is non-fatal
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value.tokensRefreshed).toBe(3);
+      expect(result.value.tokensRefreshed).toBe(4);
       expect(result.value.skypeTokenRefreshed).toBe(false);
     }
   });

--- a/src/auth/token-refresh-http.ts
+++ b/src/auth/token-refresh-http.ts
@@ -138,6 +138,11 @@ const REFRESH_SCOPES = [
     resource: 'chatsvcagg.teams.microsoft.com',
     scopes: 'https://chatsvcagg.teams.microsoft.com/.default offline_access',
   },
+  {
+    /** Microsoft Graph — calendar read/write (create/update/cancel/RSVP) and free/busy. */
+    resource: 'graph.microsoft.com',
+    scopes: 'https://graph.microsoft.com/.default offline_access',
+  },
 ] as const;
 
 /** HTTP request timeout for token refresh calls (ms). */

--- a/src/tools/meeting-tools.test.ts
+++ b/src/tools/meeting-tools.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Unit tests for meeting/calendar tool input schemas.
+ *
+ * Tests schema validation, defaults, and boundary behaviour for the
+ * calendar management tools (create/get/update/cancel/respond/schedule).
+ *
+ * Note: Schemas are defined locally to avoid circular import issues through
+ * the tool registry. These MUST match the actual schemas in meeting-tools.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+// Local schema definitions to avoid circular imports through registry.
+// These MUST match the actual schemas in meeting-tools.ts.
+const AttendeeSchema = z.object({
+  email: z.string().email(),
+  name: z.string().optional(),
+});
+
+const CreateMeetingInputSchema = z.object({
+  subject: z.string().min(1),
+  startTime: z.string().min(1),
+  endTime: z.string().min(1),
+  attendees: z.array(AttendeeSchema).optional(),
+  body: z.string().optional(),
+  isOnlineMeeting: z.boolean().optional().default(true),
+  location: z.string().optional(),
+});
+
+const GetMeetingInputSchema = z.object({
+  eventId: z.string().min(1),
+});
+
+const UpdateMeetingInputSchema = z.object({
+  eventId: z.string().min(1),
+  subject: z.string().min(1).optional(),
+  startTime: z.string().min(1).optional(),
+  endTime: z.string().min(1).optional(),
+  attendees: z.array(AttendeeSchema).optional(),
+  body: z.string().optional(),
+  location: z.string().optional(),
+});
+
+const CancelMeetingInputSchema = z.object({
+  eventId: z.string().min(1),
+});
+
+const RespondToMeetingInputSchema = z.object({
+  eventId: z.string().min(1),
+  response: z.enum(['accept', 'tentativelyAccept', 'decline']),
+  comment: z.string().optional(),
+  sendResponse: z.boolean().optional().default(true),
+  proposedNewTime: z.object({
+    start: z.string().min(1),
+    end: z.string().min(1),
+  }).optional(),
+});
+
+const GetScheduleInputSchema = z.object({
+  schedules: z.array(z.string().email()).min(1),
+  startTime: z.string().min(1),
+  endTime: z.string().min(1),
+  availabilityViewInterval: z.number().min(5).max(1440).optional().default(30),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CreateMeetingInputSchema
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CreateMeetingInputSchema', () => {
+  it('accepts the minimal required fields and defaults isOnlineMeeting', () => {
+    const result = CreateMeetingInputSchema.parse({
+      subject: 'Sync',
+      startTime: '2026-06-05T10:00:00Z',
+      endTime: '2026-06-05T10:30:00Z',
+    });
+    expect(result.subject).toBe('Sync');
+    expect(result.isOnlineMeeting).toBe(true);
+    expect(result.attendees).toBeUndefined();
+  });
+
+  it('accepts attendees with valid emails and optional names', () => {
+    const result = CreateMeetingInputSchema.parse({
+      subject: 'Sync',
+      startTime: '2026-06-05T10:00:00Z',
+      endTime: '2026-06-05T10:30:00Z',
+      attendees: [
+        { email: 'chris@company.com', name: 'Chris' },
+        { email: 'noah@company.com' },
+      ],
+    });
+    expect(result.attendees).toHaveLength(2);
+    expect(result.attendees?.[1].name).toBeUndefined();
+  });
+
+  it('allows overriding isOnlineMeeting to false', () => {
+    const result = CreateMeetingInputSchema.parse({
+      subject: 'In person',
+      startTime: '2026-06-05T10:00:00Z',
+      endTime: '2026-06-05T10:30:00Z',
+      isOnlineMeeting: false,
+      location: 'Room 1',
+    });
+    expect(result.isOnlineMeeting).toBe(false);
+    expect(result.location).toBe('Room 1');
+  });
+
+  it('rejects an empty subject', () => {
+    expect(() => CreateMeetingInputSchema.parse({
+      subject: '',
+      startTime: '2026-06-05T10:00:00Z',
+      endTime: '2026-06-05T10:30:00Z',
+    })).toThrow();
+  });
+
+  it('rejects a missing startTime', () => {
+    expect(() => CreateMeetingInputSchema.parse({
+      subject: 'Sync',
+      endTime: '2026-06-05T10:30:00Z',
+    })).toThrow();
+  });
+
+  it('rejects an invalid attendee email', () => {
+    expect(() => CreateMeetingInputSchema.parse({
+      subject: 'Sync',
+      startTime: '2026-06-05T10:00:00Z',
+      endTime: '2026-06-05T10:30:00Z',
+      attendees: [{ email: 'not-an-email' }],
+    })).toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GetMeetingInputSchema / CancelMeetingInputSchema
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GetMeetingInputSchema', () => {
+  it('accepts a non-empty eventId', () => {
+    const result = GetMeetingInputSchema.parse({ eventId: 'abc123' });
+    expect(result.eventId).toBe('abc123');
+  });
+
+  it('rejects an empty eventId', () => {
+    expect(() => GetMeetingInputSchema.parse({ eventId: '' })).toThrow();
+  });
+});
+
+describe('CancelMeetingInputSchema', () => {
+  it('accepts a non-empty eventId', () => {
+    expect(CancelMeetingInputSchema.parse({ eventId: 'abc123' }).eventId).toBe('abc123');
+  });
+
+  it('rejects a missing eventId', () => {
+    expect(() => CancelMeetingInputSchema.parse({})).toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UpdateMeetingInputSchema
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('UpdateMeetingInputSchema', () => {
+  it('accepts eventId with no other fields', () => {
+    const result = UpdateMeetingInputSchema.parse({ eventId: 'abc123' });
+    expect(result.eventId).toBe('abc123');
+    expect(result.subject).toBeUndefined();
+  });
+
+  it('accepts a partial update with only a new time', () => {
+    const result = UpdateMeetingInputSchema.parse({
+      eventId: 'abc123',
+      startTime: '2026-06-05T11:00:00Z',
+      endTime: '2026-06-05T11:30:00Z',
+    });
+    expect(result.startTime).toBe('2026-06-05T11:00:00Z');
+  });
+
+  it('rejects an empty subject when provided', () => {
+    expect(() => UpdateMeetingInputSchema.parse({
+      eventId: 'abc123',
+      subject: '',
+    })).toThrow();
+  });
+
+  it('rejects an invalid attendee email', () => {
+    expect(() => UpdateMeetingInputSchema.parse({
+      eventId: 'abc123',
+      attendees: [{ email: 'nope' }],
+    })).toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RespondToMeetingInputSchema
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RespondToMeetingInputSchema', () => {
+  it('accepts a valid response and defaults sendResponse to true', () => {
+    const result = RespondToMeetingInputSchema.parse({
+      eventId: 'abc123',
+      response: 'accept',
+    });
+    expect(result.response).toBe('accept');
+    expect(result.sendResponse).toBe(true);
+  });
+
+  it('accepts a decline with a proposed new time and comment', () => {
+    const result = RespondToMeetingInputSchema.parse({
+      eventId: 'abc123',
+      response: 'decline',
+      comment: 'Conflicts with another call',
+      sendResponse: false,
+      proposedNewTime: {
+        start: '2026-06-06T10:00:00Z',
+        end: '2026-06-06T10:30:00Z',
+      },
+    });
+    expect(result.sendResponse).toBe(false);
+    expect(result.proposedNewTime?.start).toBe('2026-06-06T10:00:00Z');
+  });
+
+  it('rejects an unknown response value', () => {
+    expect(() => RespondToMeetingInputSchema.parse({
+      eventId: 'abc123',
+      response: 'maybe',
+    })).toThrow();
+  });
+
+  it('rejects a proposedNewTime missing the end field', () => {
+    expect(() => RespondToMeetingInputSchema.parse({
+      eventId: 'abc123',
+      response: 'decline',
+      proposedNewTime: { start: '2026-06-06T10:00:00Z' },
+    })).toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GetScheduleInputSchema
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GetScheduleInputSchema', () => {
+  it('accepts a single schedule and defaults the interval to 30', () => {
+    const result = GetScheduleInputSchema.parse({
+      schedules: ['chris@company.com'],
+      startTime: '2026-06-05T09:00:00Z',
+      endTime: '2026-06-05T18:00:00Z',
+    });
+    expect(result.schedules).toEqual(['chris@company.com']);
+    expect(result.availabilityViewInterval).toBe(30);
+  });
+
+  it('rejects an empty schedules array', () => {
+    expect(() => GetScheduleInputSchema.parse({
+      schedules: [],
+      startTime: '2026-06-05T09:00:00Z',
+      endTime: '2026-06-05T18:00:00Z',
+    })).toThrow();
+  });
+
+  it('rejects a non-email entry in schedules', () => {
+    expect(() => GetScheduleInputSchema.parse({
+      schedules: ['not-an-email'],
+      startTime: '2026-06-05T09:00:00Z',
+      endTime: '2026-06-05T18:00:00Z',
+    })).toThrow();
+  });
+
+  it('accepts the interval at boundary values', () => {
+    const min = GetScheduleInputSchema.parse({
+      schedules: ['a@company.com'],
+      startTime: '2026-06-05T09:00:00Z',
+      endTime: '2026-06-05T18:00:00Z',
+      availabilityViewInterval: 5,
+    });
+    expect(min.availabilityViewInterval).toBe(5);
+
+    const max = GetScheduleInputSchema.parse({
+      schedules: ['a@company.com'],
+      startTime: '2026-06-05T09:00:00Z',
+      endTime: '2026-06-05T18:00:00Z',
+      availabilityViewInterval: 1440,
+    });
+    expect(max.availabilityViewInterval).toBe(1440);
+  });
+
+  it('rejects an interval below the minimum', () => {
+    expect(() => GetScheduleInputSchema.parse({
+      schedules: ['a@company.com'],
+      startTime: '2026-06-05T09:00:00Z',
+      endTime: '2026-06-05T18:00:00Z',
+      availabilityViewInterval: 4,
+    })).toThrow();
+  });
+
+  it('rejects an interval above the maximum', () => {
+    expect(() => GetScheduleInputSchema.parse({
+      schedules: ['a@company.com'],
+      startTime: '2026-06-05T09:00:00Z',
+      endTime: '2026-06-05T18:00:00Z',
+      availabilityViewInterval: 1441,
+    })).toThrow();
+  });
+});

--- a/src/tools/meeting-tools.ts
+++ b/src/tools/meeting-tools.ts
@@ -314,7 +314,7 @@ async function handleCancelMeeting(
 
 const respondToMeetingToolDefinition: Tool = {
   name: 'teams_respond_to_meeting',
-  description: 'Accept, tentatively accept, or decline a Teams meeting invite. Optionally include a comment to send to the organiser. When declining, you can propose an alternative time. Set sendResponse to false to update your calendar silently without emailing the organiser.',
+  description: 'Accept, tentatively accept, or decline a Teams meeting invite. Optionally include a comment to send to the organiser (the comment is only sent when sendResponse is true). When declining or tentatively accepting, you can propose an alternative time. Set sendResponse to false to update your calendar silently without emailing the organiser.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -337,7 +337,7 @@ const respondToMeetingToolDefinition: Tool = {
       },
       proposedNewTime: {
         type: 'object',
-        description: 'When declining, propose an alternative time (only if the event allows it).',
+        description: 'When declining or tentatively accepting, propose an alternative time (only if the event allows it). Ignored when accepting.',
         properties: {
           start: { type: 'string', description: 'Proposed start time (ISO 8601 UTC).' },
           end: { type: 'string', description: 'Proposed end time (ISO 8601 UTC).' },

--- a/src/tools/meeting-tools.ts
+++ b/src/tools/meeting-tools.ts
@@ -6,7 +6,15 @@ import { z } from 'zod';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { RegisteredTool, ToolContext, ToolResult } from './index.js';
 import { handleApiResult } from './index.js';
-import { getCalendarView } from '../api/calendar-api.js';
+import {
+  getCalendarView,
+  createMeeting,
+  getMeeting,
+  updateMeeting,
+  cancelMeeting,
+  respondToMeeting,
+  getSchedule,
+} from '../api/calendar-api.js';
 import { getTranscriptContent } from '../api/transcript-api.js';
 import {
   DEFAULT_MEETING_LIMIT,
@@ -26,6 +34,58 @@ export const GetMeetingsInputSchema = z.object({
 export const GetTranscriptInputSchema = z.object({
   threadId: z.string().min(1),
   meetingDate: z.string().optional(),
+});
+
+export const CreateMeetingInputSchema = z.object({
+  subject: z.string().min(1),
+  startTime: z.string().min(1),
+  endTime: z.string().min(1),
+  attendees: z.array(z.object({
+    email: z.string().email(),
+    name: z.string().optional(),
+  })).optional(),
+  body: z.string().optional(),
+  isOnlineMeeting: z.boolean().optional().default(true),
+  location: z.string().optional(),
+});
+
+export const GetMeetingInputSchema = z.object({
+  eventId: z.string().min(1),
+});
+
+export const UpdateMeetingInputSchema = z.object({
+  eventId: z.string().min(1),
+  subject: z.string().min(1).optional(),
+  startTime: z.string().min(1).optional(),
+  endTime: z.string().min(1).optional(),
+  attendees: z.array(z.object({
+    email: z.string().email(),
+    name: z.string().optional(),
+  })).optional(),
+  body: z.string().optional(),
+  location: z.string().optional(),
+});
+
+export const CancelMeetingInputSchema = z.object({
+  eventId: z.string().min(1),
+});
+
+export const RespondToMeetingInputSchema = z.object({
+  eventId: z.string().min(1),
+  response: z.enum(['accept', 'tentativelyAccept', 'decline']),
+  comment: z.string().optional(),
+  sendResponse: z.boolean().optional().default(true),
+  proposedNewTime: z.object({
+    start: z.string().min(1),
+    end: z.string().min(1),
+  }).optional(),
+});
+
+export const GetScheduleInputSchema = z.object({
+  schedules: z.array(z.string().email()).min(1),
+  startTime: z.string().min(1),
+  endTime: z.string().min(1),
+  availabilityViewInterval: z.number().min(5).max(1440).optional().default(30),
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -76,6 +136,278 @@ async function handleGetMeetings(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Create Meeting Tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+const createMeetingToolDefinition: Tool = {
+  name: 'teams_create_meeting',
+  description: 'Create a new Teams calendar meeting and send invites to attendees. Returns the meeting ID, subject, start/end times, and the Teams join URL. Set isOnlineMeeting to true (default) to generate a Teams meeting link. Attendees receive calendar invites automatically.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      subject: {
+        type: 'string',
+        description: 'Meeting title/subject.',
+      },
+      startTime: {
+        type: 'string',
+        description: 'Start time in ISO 8601 format (e.g., "2026-06-05T10:00:00Z"). Use UTC.',
+      },
+      endTime: {
+        type: 'string',
+        description: 'End time in ISO 8601 format (e.g., "2026-06-05T10:30:00Z"). Use UTC.',
+      },
+      attendees: {
+        type: 'array',
+        description: 'List of attendees to invite.',
+        items: {
+          type: 'object',
+          properties: {
+            email: { type: 'string', description: 'Attendee email address.' },
+            name: { type: 'string', description: 'Attendee display name (optional).' },
+          },
+          required: ['email'],
+        },
+      },
+      body: {
+        type: 'string',
+        description: 'Meeting description or agenda (plain text).',
+      },
+      isOnlineMeeting: {
+        type: 'boolean',
+        description: 'Whether to generate a Teams meeting link (default: true).',
+      },
+      location: {
+        type: 'string',
+        description: 'Meeting location (room name or free text, optional).',
+      },
+    },
+    required: ['subject', 'startTime', 'endTime'],
+  },
+};
+
+async function handleCreateMeeting(
+  input: z.infer<typeof CreateMeetingInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  const result = await createMeeting({
+    subject: input.subject,
+    startTime: input.startTime,
+    endTime: input.endTime,
+    attendees: input.attendees,
+    body: input.body,
+    isOnlineMeeting: input.isOnlineMeeting,
+    location: input.location,
+  });
+
+  return handleApiResult(result, (value) => ({
+    id: value.id,
+    subject: value.subject,
+    startTime: value.startTime,
+    endTime: value.endTime,
+    joinUrl: value.joinUrl,
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Get single meeting tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+const getMeetingToolDefinition: Tool = {
+  name: 'teams_get_meeting',
+  description: 'Get full details of a single Teams calendar event by its ID. Returns all fields including the full attendee list, meeting body/description, location, and Teams join URL. Use the eventId from teams_get_meetings results.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      eventId: {
+        type: 'string',
+        description: 'The event ID (the id field from teams_get_meetings results).',
+      },
+    },
+    required: ['eventId'],
+  },
+};
+
+async function handleGetMeeting(
+  input: z.infer<typeof GetMeetingInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  const result = await getMeeting(input.eventId);
+  return handleApiResult(result, (value) => ({ meeting: value }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Update meeting tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+const updateMeetingToolDefinition: Tool = {
+  name: 'teams_update_meeting',
+  description: 'Update (reschedule or edit) an existing Teams calendar event. Only the fields you provide are changed — omit any field to leave it unchanged. Returns the updated meeting. You must be the organiser to update the event for all attendees.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      eventId: {
+        type: 'string',
+        description: 'The event ID to update (from teams_get_meetings).',
+      },
+      subject: { type: 'string', description: 'New meeting title.' },
+      startTime: { type: 'string', description: 'New start time (ISO 8601 UTC).' },
+      endTime: { type: 'string', description: 'New end time (ISO 8601 UTC).' },
+      attendees: {
+        type: 'array',
+        description: 'Replaces the full attendee list.',
+        items: {
+          type: 'object',
+          properties: {
+            email: { type: 'string' },
+            name: { type: 'string' },
+          },
+          required: ['email'],
+        },
+      },
+      body: { type: 'string', description: 'New meeting description / agenda (plain text).' },
+      location: { type: 'string', description: 'New meeting location.' },
+    },
+    required: ['eventId'],
+  },
+};
+
+async function handleUpdateMeeting(
+  input: z.infer<typeof UpdateMeetingInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  const { eventId, ...options } = input;
+  const result = await updateMeeting(eventId, options);
+  return handleApiResult(result, (value) => ({ meeting: value }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cancel meeting tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+const cancelMeetingToolDefinition: Tool = {
+  name: 'teams_cancel_meeting',
+  description: 'Cancel or remove a Teams calendar event. If you are the organiser, this sends a cancellation notice to all attendees. If you are an attendee, this removes it from your calendar only without notifying others.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      eventId: {
+        type: 'string',
+        description: 'The event ID to cancel (from teams_get_meetings).',
+      },
+    },
+    required: ['eventId'],
+  },
+};
+
+async function handleCancelMeeting(
+  input: z.infer<typeof CancelMeetingInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  const result = await cancelMeeting(input.eventId);
+  return handleApiResult(result, () => ({ success: true }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Respond to meeting tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+const respondToMeetingToolDefinition: Tool = {
+  name: 'teams_respond_to_meeting',
+  description: 'Accept, tentatively accept, or decline a Teams meeting invite. Optionally include a comment to send to the organiser. When declining, you can propose an alternative time. Set sendResponse to false to update your calendar silently without emailing the organiser.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      eventId: {
+        type: 'string',
+        description: 'The event ID to respond to (from teams_get_meetings).',
+      },
+      response: {
+        type: 'string',
+        enum: ['accept', 'tentativelyAccept', 'decline'],
+        description: '"accept" to accept, "tentativelyAccept" for maybe, "decline" to decline.',
+      },
+      comment: {
+        type: 'string',
+        description: 'Optional message to send with your response.',
+      },
+      sendResponse: {
+        type: 'boolean',
+        description: 'Whether to notify the organiser (default: true). Set to false to update your calendar silently.',
+      },
+      proposedNewTime: {
+        type: 'object',
+        description: 'When declining, propose an alternative time (only if the event allows it).',
+        properties: {
+          start: { type: 'string', description: 'Proposed start time (ISO 8601 UTC).' },
+          end: { type: 'string', description: 'Proposed end time (ISO 8601 UTC).' },
+        },
+        required: ['start', 'end'],
+      },
+    },
+    required: ['eventId', 'response'],
+  },
+};
+
+async function handleRespondToMeeting(
+  input: z.infer<typeof RespondToMeetingInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  const result = await respondToMeeting(input.eventId, {
+    response: input.response,
+    comment: input.comment,
+    sendResponse: input.sendResponse,
+    proposedNewTime: input.proposedNewTime,
+  });
+  return handleApiResult(result, () => ({ success: true }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Get schedule (free/busy) tool
+// ─────────────────────────────────────────────────────────────────────────────
+
+const getScheduleToolDefinition: Tool = {
+  name: 'teams_get_schedule',
+  description: 'Check the free/busy availability of one or more people for a given time window. Returns each person\'s busy slots and a visual availability string (0=free, 1=tentative, 2=busy, 3=OOF) in configurable intervals. Useful for finding a good meeting time before sending an invite.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      schedules: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Email addresses of the people to check (e.g., ["chris@company.com", "atakan@company.com"]).',
+      },
+      startTime: {
+        type: 'string',
+        description: 'Start of the window to check (ISO 8601 UTC, e.g., "2026-06-05T09:00:00Z").',
+      },
+      endTime: {
+        type: 'string',
+        description: 'End of the window to check (ISO 8601 UTC, e.g., "2026-06-05T18:00:00Z").',
+      },
+      availabilityViewInterval: {
+        type: 'number',
+        description: 'Slot size in minutes for the availability string (default: 30, min: 5, max: 1440).',
+      },
+    },
+    required: ['schedules', 'startTime', 'endTime'],
+  },
+};
+
+async function handleGetSchedule(
+  input: z.infer<typeof GetScheduleInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  const result = await getSchedule({
+    schedules: input.schedules,
+    startTime: input.startTime,
+    endTime: input.endTime,
+    availabilityViewInterval: input.availabilityViewInterval,
+  });
+  return handleApiResult(result, (value) => ({ schedules: value.schedules }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Transcript Tool
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -122,6 +454,42 @@ export const getMeetingsTool: RegisteredTool<typeof GetMeetingsInputSchema> = {
   handler: handleGetMeetings,
 };
 
+export const createMeetingTool: RegisteredTool<typeof CreateMeetingInputSchema> = {
+  definition: createMeetingToolDefinition,
+  schema: CreateMeetingInputSchema,
+  handler: handleCreateMeeting,
+};
+
+export const getMeetingTool: RegisteredTool<typeof GetMeetingInputSchema> = {
+  definition: getMeetingToolDefinition,
+  schema: GetMeetingInputSchema,
+  handler: handleGetMeeting,
+};
+
+export const updateMeetingTool: RegisteredTool<typeof UpdateMeetingInputSchema> = {
+  definition: updateMeetingToolDefinition,
+  schema: UpdateMeetingInputSchema,
+  handler: handleUpdateMeeting,
+};
+
+export const cancelMeetingTool: RegisteredTool<typeof CancelMeetingInputSchema> = {
+  definition: cancelMeetingToolDefinition,
+  schema: CancelMeetingInputSchema,
+  handler: handleCancelMeeting,
+};
+
+export const respondToMeetingTool: RegisteredTool<typeof RespondToMeetingInputSchema> = {
+  definition: respondToMeetingToolDefinition,
+  schema: RespondToMeetingInputSchema,
+  handler: handleRespondToMeeting,
+};
+
+export const getScheduleTool: RegisteredTool<typeof GetScheduleInputSchema> = {
+  definition: getScheduleToolDefinition,
+  schema: GetScheduleInputSchema,
+  handler: handleGetSchedule,
+};
+
 export const getTranscriptTool: RegisteredTool<typeof GetTranscriptInputSchema> = {
   definition: getTranscriptToolDefinition,
   schema: GetTranscriptInputSchema,
@@ -129,4 +497,13 @@ export const getTranscriptTool: RegisteredTool<typeof GetTranscriptInputSchema> 
 };
 
 /** All meeting-related tools. */
-export const meetingTools = [getMeetingsTool, getTranscriptTool];
+export const meetingTools = [
+  getMeetingsTool,
+  createMeetingTool,
+  getMeetingTool,
+  updateMeetingTool,
+  cancelMeetingTool,
+  respondToMeetingTool,
+  getScheduleTool,
+  getTranscriptTool,
+];

--- a/src/tools/people-tools.test.ts
+++ b/src/tools/people-tools.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for people tool input schemas.
+ *
+ * Tests schema validation for the presence lookup tool.
+ *
+ * Note: The schema is defined locally to avoid circular import issues through
+ * the tool registry. It MUST match the actual schema in people-tools.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+// Local schema definition to avoid circular imports through registry.
+// This MUST match GetPresenceInputSchema in people-tools.ts.
+const GetPresenceInputSchema = z.object({
+  userIds: z.array(z.string().min(1)).min(1),
+});
+
+describe('GetPresenceInputSchema', () => {
+  it('accepts a single user id', () => {
+    const result = GetPresenceInputSchema.parse({
+      userIds: ['8:orgid:abc-123'],
+    });
+    expect(result.userIds).toEqual(['8:orgid:abc-123']);
+  });
+
+  it('accepts multiple user ids', () => {
+    const result = GetPresenceInputSchema.parse({
+      userIds: ['8:orgid:abc', 'def-456'],
+    });
+    expect(result.userIds).toHaveLength(2);
+  });
+
+  it('rejects an empty userIds array', () => {
+    expect(() => GetPresenceInputSchema.parse({ userIds: [] })).toThrow();
+  });
+
+  it('rejects an empty string user id', () => {
+    expect(() => GetPresenceInputSchema.parse({ userIds: [''] })).toThrow();
+  });
+
+  it('rejects a missing userIds field', () => {
+    expect(() => GetPresenceInputSchema.parse({})).toThrow();
+  });
+});

--- a/src/tools/people-tools.ts
+++ b/src/tools/people-tools.ts
@@ -7,6 +7,7 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { RegisteredTool, ToolContext, ToolResult } from './index.js';
 import { handleApiResult } from './index.js';
 import { searchPeople, getFrequentContacts } from '../api/substrate-api.js';
+import { getPresence } from '../api/presence-api.js';
 import { getUserProfile } from '../auth/token-extractor.js';
 import { ErrorCode, createError } from '../types/errors.js';
 import {
@@ -27,6 +28,10 @@ export const SearchPeopleInputSchema = z.object({
 
 export const FrequentContactsInputSchema = z.object({
   limit: z.number().min(1).max(MAX_CONTACTS_LIMIT).optional().default(DEFAULT_CONTACTS_LIMIT),
+});
+
+export const GetPresenceInputSchema = z.object({
+  userIds: z.array(z.string().min(1)).min(1),
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -72,6 +77,22 @@ const frequentContactsToolDefinition: Tool = {
         description: 'Maximum number of contacts to return (default: 50)',
       },
     },
+  },
+};
+
+const getPresenceToolDefinition: Tool = {
+  name: 'teams_get_presence',
+  description: 'Get the real time presence of one or more people: availability (Available, Busy, Away, Offline, DoNotDisturb), activity (e.g. InACall, InAMeeting, Presenting), device, last active time, whether they are out of office, and their out of office auto reply message if set. Pass user identifiers (MRI like "8:orgid:<guid>" or a raw object id from teams_search_people / teams_get_frequent_contacts).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      userIds: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'User identifiers to look up: MRI ("8:orgid:<guid>") or raw object id. Get these from teams_search_people or teams_get_frequent_contacts.',
+      },
+    },
+    required: ['userIds'],
   },
 };
 
@@ -126,6 +147,15 @@ async function handleGetFrequentContacts(
   }));
 }
 
+async function handleGetPresence(
+  input: z.infer<typeof GetPresenceInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  const result = await getPresence(input.userIds);
+
+  return handleApiResult(result, (value) => ({ presences: value }));
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Exports
 // ─────────────────────────────────────────────────────────────────────────────
@@ -148,5 +178,11 @@ export const frequentContactsTool: RegisteredTool<typeof FrequentContactsInputSc
   handler: handleGetFrequentContacts,
 };
 
+export const getPresenceTool: RegisteredTool<typeof GetPresenceInputSchema> = {
+  definition: getPresenceToolDefinition,
+  schema: GetPresenceInputSchema,
+  handler: handleGetPresence,
+};
+
 /** All people-related tools. */
-export const peopleTools = [getMeTool, searchPeopleTool, frequentContactsTool];
+export const peopleTools = [getMeTool, searchPeopleTool, frequentContactsTool, getPresenceTool];

--- a/src/utils/api-config.test.ts
+++ b/src/utils/api-config.test.ts
@@ -10,11 +10,15 @@ import {
   CHATSVC_API,
   CALENDAR_API,
   CSA_API,
+  GRAPH_BASE_URL,
+  GRAPH_CALENDAR_API,
+  PRESENCE_API,
   getTeamsHeaders,
   getBearerHeaders,
   getSkypeAuthHeaders,
   getCsaHeaders,
   getMessagingHeaders,
+  getGraphHeaders,
 } from './api-config.js';
 
 describe('DEFAULT_TEAMS_BASE_URL', () => {
@@ -171,6 +175,56 @@ describe('CSA_API', () => {
   });
 });
 
+describe('GRAPH_BASE_URL', () => {
+  it('points at the v1.0 Graph endpoint', () => {
+    expect(GRAPH_BASE_URL).toBe('https://graph.microsoft.com/v1.0');
+  });
+});
+
+describe('GRAPH_CALENDAR_API', () => {
+  it('builds events URL', () => {
+    const url = GRAPH_CALENDAR_API.events();
+    expect(url).toContain('graph.microsoft.com');
+    expect(url).toContain('/me/events');
+  });
+
+  it('builds single event URL with encoded id', () => {
+    const url = GRAPH_CALENDAR_API.event('AAMk/Abc=');
+    expect(url).toContain('/me/events/');
+    expect(url).toContain('AAMk%2FAbc%3D');
+  });
+
+  it('builds respondToEvent URL for each action', () => {
+    expect(GRAPH_CALENDAR_API.respondToEvent('id1', 'accept')).toMatch(/\/me\/events\/id1\/accept$/);
+    expect(GRAPH_CALENDAR_API.respondToEvent('id1', 'tentativelyAccept')).toMatch(/\/tentativelyAccept$/);
+    expect(GRAPH_CALENDAR_API.respondToEvent('id1', 'decline')).toMatch(/\/decline$/);
+  });
+
+  it('encodes the event id in respondToEvent URL', () => {
+    const url = GRAPH_CALENDAR_API.respondToEvent('AAMk/Abc=', 'accept');
+    expect(url).toContain('AAMk%2FAbc%3D');
+  });
+
+  it('builds getSchedule URL', () => {
+    const url = GRAPH_CALENDAR_API.getSchedule();
+    expect(url).toContain('/me/calendar/getSchedule');
+  });
+});
+
+describe('PRESENCE_API', () => {
+  it('builds getPresence URL with region', () => {
+    const url = PRESENCE_API.getPresence('emea');
+    expect(url).toContain(DEFAULT_TEAMS_BASE_URL);
+    expect(url).toContain('/ups/emea/');
+    expect(url).toContain('getpresence');
+  });
+
+  it('accepts custom baseUrl for government clouds', () => {
+    const url = PRESENCE_API.getPresence('emea', 'https://teams.microsoft.us');
+    expect(url).toContain('teams.microsoft.us');
+  });
+});
+
 describe('getTeamsHeaders', () => {
   it('returns headers with content-type and origin', () => {
     const headers = getTeamsHeaders();
@@ -235,5 +289,15 @@ describe('getMessagingHeaders', () => {
     
     expect(headers['Authentication']).toContain('skypetoken');
     expect(headers['Authorization']).toContain('Bearer');
+  });
+});
+
+describe('getGraphHeaders', () => {
+  it('adds Authorization bearer and JSON headers', () => {
+    const headers = getGraphHeaders('graph-token');
+
+    expect(headers['Authorization']).toBe('Bearer graph-token');
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers['Accept']).toBe('application/json');
   });
 });

--- a/src/utils/api-config.ts
+++ b/src/utils/api-config.ts
@@ -142,6 +142,68 @@ export const CALENDAR_API = {
     hasPartition
       ? `${baseUrl}/api/mt/part/${regionPartition}/v2.1/me/calendars/calendarView`
       : `${baseUrl}/api/mt/${regionPartition}/v2.1/me/calendars/calendarView`,
+
+} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Microsoft Graph Calendar API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Microsoft Graph API base URL. */
+export const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+
+/**
+ * Microsoft Graph calendar endpoints.
+ *
+ * The Teams web client performs calendar writes (create/update/cancel/RSVP) and
+ * free/busy lookups against graph.microsoft.com, not the mt/part middle-tier API.
+ * These use a Graph bearer token (Calendars.ReadWrite scope) extracted from the
+ * same session. Event IDs returned by the mt/part calendarView are compatible
+ * with these Graph endpoints.
+ */
+export const GRAPH_CALENDAR_API = {
+  /** Create a new event (POST) or list events (GET). */
+  events: () => `${GRAPH_BASE_URL}/me/events`,
+
+  /** Get (GET), update (PATCH), or delete (DELETE) a single event by ID. */
+  event: (eventId: string) => `${GRAPH_BASE_URL}/me/events/${encodeURIComponent(eventId)}`,
+
+  /**
+   * RSVP to an event.
+   *
+   * @param action - "accept" | "tentativelyAccept" | "decline"
+   */
+  respondToEvent: (eventId: string, action: 'accept' | 'tentativelyAccept' | 'decline') =>
+    `${GRAPH_BASE_URL}/me/events/${encodeURIComponent(eventId)}/${action}`,
+
+  /** Get free/busy schedule for one or more users (POST). */
+  getSchedule: () => `${GRAPH_BASE_URL}/me/calendar/getSchedule`,
+} as const;
+
+/** Headers for Microsoft Graph API calls. */
+export function getGraphHeaders(token: string): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'Authorization': `Bearer ${token}`,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Presence API (UPS)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * User Presence Service (UPS) endpoints.
+ *
+ * Returns availability/activity plus calendar-derived out of office state and
+ * the user's auto reply note. Uses the base region (e.g. "emea"), not the
+ * partitioned region, and authenticates with the Skype Spaces token as Bearer.
+ */
+export const PRESENCE_API = {
+  /** Fetch presence for a batch of users (POST). */
+  getPresence: (region: string, baseUrl = DEFAULT_TEAMS_BASE_URL) =>
+    `${baseUrl}/ups/${region}/v1/presence/getpresence/`,
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/utils/auth-guards.ts
+++ b/src/utils/auth-guards.ts
@@ -13,6 +13,7 @@ import {
   extractCsaToken,
   extractSubstrateToken,
   extractSkypeSpacesToken,
+  extractGraphToken,
   extractRegionConfig,
   getUserProfile,
   clearTokenCache,
@@ -142,6 +143,26 @@ export function requireSkypeSpacesAuth(): Result<SkypeSpacesAuthInfo, McpError> 
   }
 
   return ok({ skypeToken: auth.skypeToken, spacesToken });
+}
+
+/**
+ * Requires a valid Microsoft Graph API token.
+ *
+ * Use for calendar write operations (create/update/cancel/RSVP) and free/busy
+ * lookups, which go through graph.microsoft.com rather than the mt/part API.
+ */
+export function requireGraphAuth(): Result<string, McpError> {
+  const graphToken = extractGraphToken();
+
+  if (!graphToken) {
+    return err(createError(
+      ErrorCode.AUTH_REQUIRED,
+      'Calendar write access requires a Microsoft Graph token. Please run teams_login.',
+      { suggestions: ['Call teams_login to authenticate'] }
+    ));
+  }
+
+  return ok(graphToken);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds seven tools: six for Teams calendar management (create, read single, update, cancel, RSVP, free/busy) and one for reading user presence (including the out of office auto reply message). All verified end to end against a live tenant.

Supersedes #16.

## New tools

| Tool | Description |
|------|-------------|
| `teams_create_meeting` | Create a meeting with attendees and a Teams join link |
| `teams_get_meeting` | Full detail of a single event (attendees, body, join URL) |
| `teams_update_meeting` | Reschedule or edit, only provided fields change (PATCH) |
| `teams_cancel_meeting` | Cancel as organiser (notifies attendees) or remove as attendee |
| `teams_respond_to_meeting` | RSVP accept, tentative, or decline, with optional comment and proposed new time |
| `teams_get_schedule` | Free/busy availability for one or more people |
| `teams_get_presence` | Availability, activity, device, last active time, out of office state, and out of office auto reply message for one or more people |

## Approach

### Calendar (Microsoft Graph)

The existing `teams_get_meetings` reads via the `mt/part` middle tier API, which does not expose event writes. The Teams web client performs calendar writes and free/busy lookups via Microsoft Graph (`graph.microsoft.com/v1.0/me/events` and `/me/calendar/getSchedule`), so the calendar tools use Graph:

- `extractGraphToken()` pulls the `graph.microsoft.com` token (Calendars.ReadWrite) already present in the session, refreshed by the existing `teams_login` flow.
- `requireGraphAuth()` guard mirrors the existing auth guard pattern.
- `GRAPH_CALENDAR_API`, `GRAPH_BASE_URL`, and `getGraphHeaders()` added to `api-config.ts`.
- Event ids returned by the `mt/part` `calendarView` are compatible with Graph `/me/events/{id}`, so `teams_get_meetings` output feeds straight into the new tools.

`getCalendarView` is unchanged and stays on `mt/part`.

### Presence (Teams UPS)

`teams_get_presence` calls the Teams User Presence Service: `POST /ups/{geoRegion}/v1/presence/getpresence/` with the Skype Spaces token. The geo region is the prefix of the partitioned region (`emea` from `emea-02`), not the chatsvc country code. It returns availability, activity, device, last active time, out of office state, and the out of office auto reply note.

## Files changed

- `src/auth/token-extractor.ts`: `extractGraphToken()`
- `src/utils/auth-guards.ts`: `requireGraphAuth()`
- `src/utils/api-config.ts`: `GRAPH_CALENDAR_API`, `GRAPH_BASE_URL`, `getGraphHeaders()`, `PRESENCE_API`
- `src/api/calendar-api.ts`: `createMeeting`, `getMeeting`, `updateMeeting`, `cancelMeeting`, `respondToMeeting`, `getSchedule`, plus `parseGraphEvent` and `buildGraphEventBody` helpers; `schedulingServiceUpdateUrl` exposed on the `Meeting` type
- `src/api/presence-api.ts`: new module, `getPresence()` plus `UserPresence` type
- `src/tools/meeting-tools.ts`: calendar tool schemas, definitions, handlers, exports
- `src/tools/people-tools.ts`: `teams_get_presence` schema, definition, handler, export

## Testing

Verified end to end against a live tenant (build is clean, zero TypeScript errors):

- `getSchedule`: returns a real availability view plus busy slots
- `createMeeting`: event created with a Teams join URL
- `getMeeting`: full event detail
- `updateMeeting`: subject updated
- `respondToMeeting`: changed an attendee event from "None" to "Tentative" (HTTP 202); also verified the organiser RSVP and comment/sendResponse constraints
- `cancelMeeting`: event deleted
- `getPresence`: returns availability, out of office state, and the auto reply note for multiple users in one call

Notes:
- `respondToMeeting` only sends a comment when `sendResponse` is true, since Graph returns 400 otherwise.
- You cannot RSVP to a meeting you organise (Graph rejects it), which is expected.
