### PR TITLE
feat: support quoted replies in chats via replyToMessageId

### DIFF
--- a/src/api/chatsvc-messaging.test.ts
+++ b/src/api/chatsvc-messaging.test.ts
@@ -10,7 +10,22 @@ import {
   buildMentionHtml,
   buildMentionsProperty,
   parseContentWithMentionsAndLinks,
+  buildReplyQuoteHtml,
+  type ThreadMessage,
 } from './chatsvc-messaging.js';
+
+/** Minimal ThreadMessage factory for quote tests. */
+function makeMessage(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
+  return {
+    id: '1780429789320',
+    content: 'original message',
+    contentType: 'RichText/Html',
+    sender: { mri: '8:orgid:abc-123', displayName: 'Alice' },
+    timestamp: '2026-06-02T20:55:00Z',
+    conversationId: '48:notes',
+    ...overrides,
+  };
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // buildMentionHtml
@@ -154,5 +169,48 @@ describe('parseContentWithMentionsAndLinks', () => {
     expect(mentions[0].mri).toBe('tag:abc');
     expect(html).toContain('<a href="https://example.com">docs</a>');
     expect(html).toContain('my-tag');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildReplyQuoteHtml
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildReplyQuoteHtml', () => {
+  it('builds a Skype Reply block with sender, id and preview', () => {
+    const html = buildReplyQuoteHtml(makeMessage());
+    expect(html).toContain('itemtype="http://schema.skype.com/Reply"');
+    expect(html).toContain('itemid="1780429789320"');
+    expect(html).toContain('itemprop="mri" itemid="8:orgid:abc-123"');
+    expect(html).toContain('>Alice<');
+    expect(html).toContain('<p itemprop="preview">original message</p>');
+    expect(html.startsWith('<blockquote')).toBe(true);
+    expect(html.endsWith('</blockquote>')).toBe(true);
+  });
+
+  it('normalises a full contact-URL MRI to its bare form', () => {
+    const html = buildReplyQuoteHtml(
+      makeMessage({
+        sender: {
+          mri: 'https://teams.microsoft.com/api/chatsvc/uk/v1/users/ME/contacts/8:orgid:abc-123',
+          displayName: 'Alice',
+        },
+      })
+    );
+    expect(html).toContain('itemid="8:orgid:abc-123"');
+    expect(html).not.toContain('contacts/');
+  });
+
+  it('escapes HTML in the sender name and preview', () => {
+    const html = buildReplyQuoteHtml(
+      makeMessage({ content: '1 < 2 & 3 > 0', sender: { mri: '8:orgid:x', displayName: '<b>Bob</b>' } })
+    );
+    expect(html).toContain('&lt;b&gt;Bob&lt;/b&gt;');
+    expect(html).toContain('1 &lt; 2 &amp; 3 &gt; 0');
+  });
+
+  it('falls back to Unknown when the display name is missing', () => {
+    const html = buildReplyQuoteHtml(makeMessage({ sender: { mri: '8:orgid:x' } }));
+    expect(html).toContain('>Unknown<');
   });
 });

--- a/src/api/chatsvc-messaging.ts
+++ b/src/api/chatsvc-messaging.ts
@@ -11,7 +11,7 @@ import { ErrorCode, createError } from '../types/errors.js';
 import { type Result, ok, err } from '../types/result.js';
 import { getUserDisplayName } from '../auth/token-extractor.js';
 import { requireMessageAuth, requireMessageAuthWithConfig, getTeamsBaseUrl, getTenantId } from '../utils/auth-guards.js';
-import { stripHtml, extractLinks, buildMessageLink, buildOneOnOneConversationId, extractObjectId, markdownToTeamsHtml, escapeHtmlChars, type ExtractedLink } from '../utils/parsers.js';
+import { stripHtml, extractLinks, buildMessageLink, buildOneOnOneConversationId, extractObjectId, getConversationType, markdownToTeamsHtml, escapeHtmlChars, type ExtractedLink } from '../utils/parsers.js';
 import { SELF_CHAT_ID, MRI_ORGID_PREFIX } from '../constants.js';
 import { formatHumanReadableDate } from './chatsvc-common.js';
 import type { RawChatsvcMessage, RawConversationResponse, RawCreateThreadResponse } from '../types/api-responses.js';
@@ -85,17 +85,39 @@ function getActualMri(mri: string): string {
   return isTagMention(mri) ? mri.substring(4) : mri;
 }
 
+/**
+ * Builds a Skype "Reply" quoted block referencing an existing message.
+ *
+ * Used for chats (1:1, group, meeting) where native reply chains are not
+ * allowed: the block is prepended to the outgoing message content and Teams
+ * renders it as a quoted reply card above the new text. The sender MRI is
+ * normalised to its bare form (e.g. `8:orgid:<guid>`) and all text is escaped.
+ */
+export function buildReplyQuoteHtml(quote: ThreadMessage): string {
+  const mriMatch = quote.sender.mri.match(/(?:8:|48:|28:)[^/"]+/);
+  const senderMri = mriMatch ? mriMatch[0] : quote.sender.mri;
+  const senderName = escapeHtmlChars(quote.sender.displayName || 'Unknown');
+  const preview = escapeHtmlChars(quote.content.slice(0, 1000));
+  return (
+    `<blockquote itemscope itemtype="http://schema.skype.com/Reply" itemid="${quote.id}">` +
+    `<strong itemprop="mri" itemid="${senderMri}">${senderName}</strong>` +
+    `<span itemprop="time" itemid="${quote.id}"></span>` +
+    `<p itemprop="preview">${preview}</p></blockquote>`
+  );
+}
+
 /** Options for sending a message. */
 export interface SendMessageOptions {
   /**
    * Message ID of the thread root to reply to.
    * 
-   * When provided, the message is posted as a reply to an existing thread
-   * in a channel. The conversationId should be the channel ID, and this
+   * In a channel, the message is posted as a native reply within the
+   * referenced thread. The conversationId should be the channel ID, and this
    * should be the ID of the first message in the thread.
    * 
-   * For chats (1:1, group, meeting), this is not needed - all messages
-   * are part of the same flat conversation.
+   * In a chat (1:1, group, meeting), threaded reply chains are not allowed,
+   * so the referenced message is instead embedded as a quoted reply block at
+   * the top of the message and posted normally.
    */
   replyToMessageId?: string;
 }
@@ -131,7 +153,8 @@ export interface CreateGroupChatResult {
  * - Reply to a thread: provide the channel's conversationId AND replyToMessageId
  * 
  * For chats (1:1, group, meeting), all messages go to the same conversation
- * without threading - just provide the conversationId.
+ * without threading. Passing replyToMessageId there embeds a quoted reply
+ * block referencing that message (reply chains are channel-only).
  */
 export async function sendMessage(
   conversationId: string,
@@ -153,8 +176,22 @@ export async function sendMessage(
   // Always convert through markdown→HTML pipeline (never pass user content through
   // without sanitization, as Teams requires proper block-level wrapping like <p> tags)
   const parsed = parseContentWithMentionsAndLinks(content);
-  const htmlContent = parsed.html;
+  let htmlContent = parsed.html;
   const mentionsToSend = parsed.mentions;
+
+  // Reply handling. Channels support native reply chains via the URL. Chats
+  // (1:1, group, meeting) reject reply chains ("Reply chains is not allowed in
+  // this thread type"), so when replyToMessageId is given for a chat we embed a
+  // Skype "Reply" quoted block referencing the original and post it normally.
+  let threadReplyId = replyToMessageId;
+  if (replyToMessageId && getConversationType(conversationId) !== 'channel') {
+    const original = await getMessage(conversationId, replyToMessageId);
+    if (original.ok) {
+      htmlContent = buildReplyQuoteHtml(original.value) + htmlContent;
+    }
+    // The quote is carried in the body, so post as a normal (non-threaded) message.
+    threadReplyId = undefined;
+  }
 
   // Build the message body
   const body: Record<string, unknown> = {
@@ -172,7 +209,7 @@ export async function sendMessage(
     };
   }
 
-  const url = CHATSVC_API.messages(region, conversationId, replyToMessageId, baseUrl);
+  const url = CHATSVC_API.messages(region, conversationId, threadReplyId, baseUrl);
 
   const response = await httpRequest<{ OriginalArrivalTime?: number }>(
     url,


### PR DESCRIPTION
## Summary

Reply chains only work in channel threads. In chats (1:1, group, meeting) the chatsvc API rejects them with `Reply chains is not allowed in this thread type`, so passing `replyToMessageId` for a chat used to fail outright.

This makes `replyToMessageId` work in chats: the referenced message is fetched and embedded as a Skype "Reply" quoted block at the top of the outgoing message, which is then posted as a normal (non-threaded) message. Teams renders it as a quoted reply card above the new text. **Channels are unchanged** and still use native reply chains.

## Approach

- Channel vs chat is detected with the existing `getConversationType()` helper.
- The quote block is built by a new pure helper, `buildReplyQuoteHtml()`, which normalises the sender MRI to its bare form (e.g. `8:orgid:<guid>`) and HTML-escapes the sender name and preview.

## Screenshot

A quoted reply in a chat, rendered in the Teams web client (original sender name blurred):

![chat quoted reply](https://github.com/user-attachments/assets/2e350f74-6e3d-4ed5-ba8a-dc29ffeb7628)

## Caveat (honest note)

Teams shows a small "This quoted message isn't verified by Teams" indicator on quoted replies that were not created by its own client (the same indicator appears on Graph/bot-posted quotes). This is an anti-spoofing provenance signal and is expected for an API-posted quote; the quote still renders with the correct referenced sender and text. The native verified badge is signed server-side and cannot be reproduced by an external client.

## Testing

- Added unit tests for `buildReplyQuoteHtml` in `src/api/chatsvc-messaging.test.ts` (Skype Reply structure, MRI normalisation from a contact URL, HTML escaping, missing display name).
- `npm run build` (tsc) clean, `eslint` clean, full suite green (341 tests).


---

**Suggested label:** `enhancement`

_(Suggesting rather than applying: as an external fork contributor I don't have permission to set labels on this repo. Feel free to apply it on triage.)_