### PR TITLE
fix: keep multi-mention itemids aligned so mentions resolve to the right people

### DIFF
--- a/src/api/chatsvc-messaging.test.ts
+++ b/src/api/chatsvc-messaging.test.ts
@@ -140,6 +140,40 @@ describe('parseContentWithMentionsAndLinks', () => {
     expect(html).toContain('my-tag');
   });
 
+  it('keeps inline span itemids aligned with the mentions array for multiple mentions', () => {
+    // Regression: the inline <span itemid> was numbered in reverse
+    // placeholder-processing order while the mentions array (and
+    // buildMentionsProperty, which keys by array index) stayed source-ordered.
+    // That mismatch reversed the mention→MRI mapping: one mention was fine, two
+    // swapped, three reversed (middle fixed).
+    const { html, mentions } = parseContentWithMentionsAndLinks(
+      '@[Noah](8:orgid:noah) @[Kubra](8:orgid:kubra) @[Atakan](8:orgid:atakan)'
+    );
+
+    expect(mentions.map((m) => m.mri)).toEqual([
+      '8:orgid:noah',
+      '8:orgid:kubra',
+      '8:orgid:atakan',
+    ]);
+
+    // The itemid on each name's span must equal that mention's index in the array.
+    const itemIdFor = (name: string): number => {
+      const match = html.match(new RegExp(`itemid="(\\d+)"[^>]*>${name}<`));
+      if (!match) throw new Error(`no mention span found for ${name}`);
+      return Number(match[1]);
+    };
+    expect(itemIdFor('Noah')).toBe(0);
+    expect(itemIdFor('Kubra')).toBe(1);
+    expect(itemIdFor('Atakan')).toBe(2);
+
+    // And the property built from that array resolves each span's itemid back to
+    // the correct MRI (this is what Teams uses to render the chip / notify).
+    const props = JSON.parse(buildMentionsProperty(mentions));
+    expect(props[itemIdFor('Noah')].mri).toBe('8:orgid:noah');
+    expect(props[itemIdFor('Kubra')].mri).toBe('8:orgid:kubra');
+    expect(props[itemIdFor('Atakan')].mri).toBe('8:orgid:atakan');
+  });
+
   it('returns markdown-converted HTML when no mentions or links', () => {
     const { html, mentions } = parseContentWithMentionsAndLinks('Just plain text');
     expect(mentions).toHaveLength(0);

--- a/src/api/chatsvc-messaging.ts
+++ b/src/api/chatsvc-messaging.ts
@@ -984,9 +984,24 @@ export function parseContentWithMentionsAndLinks(content: string): { html: strin
   // Strategy: replace mentions/links with unique placeholders, run the whole
   // content through markdownToTeamsHtml (so links stay inline within their
   // paragraph), then substitute placeholders back with actual HTML.
+  //
+  // Assign each mention a stable id up front, based on its source-order
+  // position. This same id is used for the inline <span itemid> AND as the
+  // mention's index in the returned array. buildMentionsProperty() keys each
+  // entry by its array index, so the inline itemid and the property itemid must
+  // agree. Numbering the spans in placeholder-processing order (reverse) instead
+  // would mismatch the source-ordered array and reverse the mention→MRI mapping
+  // (a single mention is unaffected, two swap, three reverse, etc.).
   const mentions: Mention[] = [];
+  const mentionIdByMatch = new Map<number, number>();
+  matches.forEach((m, i) => {
+    if (m.type === 'mention') {
+      mentionIdByMatch.set(i, mentions.length);
+      mentions.push({ mri: m.target, displayName: m.text });
+    }
+  });
+
   const placeholders: Map<string, string> = new Map();
-  let mentionId = 0;
   
   // Build content with placeholders (process in reverse to preserve indices).
   // Uses Unicode Private Use Area characters (U+E000, U+E001) as delimiters —
@@ -998,9 +1013,7 @@ export function parseContentWithMentionsAndLinks(content: string): { html: strin
     
     let html: string;
     if (m.type === 'mention') {
-      mentions.push({ mri: m.target, displayName: m.text });
-      html = buildMentionHtml(m.text, mentionId, m.target);
-      mentionId++;
+      html = buildMentionHtml(m.text, mentionIdByMatch.get(i)!, m.target);
     } else {
       const safeText = escapeHtmlChars(m.text);
       const safeUrl = m.target.replace(/"/g, '&quot;');
@@ -1010,9 +1023,6 @@ export function parseContentWithMentionsAndLinks(content: string): { html: strin
     
     placeholderContent = placeholderContent.substring(0, m.index) + placeholder + placeholderContent.substring(m.index + m.length);
   }
-  
-  // Reverse mentions array since we processed in reverse order
-  mentions.reverse();
   
   // Convert the whole content (with placeholders) through markdown pipeline
   let result = markdownToTeamsHtml(placeholderContent);


### PR DESCRIPTION
## Problem

When a message contains **more than one** @mention, the mentions resolve to the wrong people. The displayed mention chips and the actual notifications are mapped to the wrong MRIs:

- **1 mention:** correct
- **2 mentions:** swapped
- **3 mentions:** reversed (middle stays put)

The plain text you copy from the message looks correct, which masks the bug, because the copied text comes from the inline display text while Teams renders the chip and routes the notification from the MRI mapping.

Reproduced against a Microsoft 365 corporate tenant: sending `@[A] @[B] @[C]` to a self-chat rendered the chips (and opened the profiles) as `C, B, A`.

## Root cause

In `parseContentWithMentionsAndLinks()` the placeholder substitution runs in reverse (last match first) to keep string indices valid. The inline `<span itemid>` was numbered using a counter incremented in that **reverse** order, then the `mentions` array was `reverse()`d back to source order before returning.

`buildMentionsProperty()` keys each entry by its **array index** (source order). So the inline span itemids (reverse order) and the mentions-property itemids (source order) referred to different mentions. Teams matches a span to its property entry by itemid, so each mention resolved to the reversed MRI. With one mention there is nothing to reverse, hence it always worked.

## Fix

Assign each mention a stable id from its **source-order position** up front, and use that same id for both the inline `<span itemid>` and its index in the returned `mentions` array. The two itemid spaces now always agree, regardless of how many mentions there are or the reverse processing order. No behaviour change for links or single mentions.

## Testing

- Added a regression test in `src/api/chatsvc-messaging.test.ts` that parses three mentions and asserts each name's span itemid maps back to the correct MRI via `buildMentionsProperty`. Verified it **fails on `main`** (reversed mapping) and passes with this change.
- `npm run build` (tsc) clean, `eslint` clean, full suite green (338 tests).


---

**Suggested label:** `bug`

_(Suggesting rather than applying: as an external fork contributor I don't have permission to set labels on this repo. Feel free to apply it on triage.)_