### PR TITLE
feat: chat list, wait-for-reply, scheduling, deep-link input & content-type control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,9 @@ Session state and token cache files are protected by:
 |------|---------|
 | `teams_search` | Search Teams messages with query operators, supports pagination |
 | `teams_search_email` | Search emails in user's mailbox (same Substrate token as Teams search) |
-| `teams_send_message` | Send a message (markdown); person `@[Name](mri)` or channel tag `@[Tag](tag:id)` via `teams_get_tags`; `replyToMessageId` for channel thread replies |
+| `teams_list_chats` | List recent conversations (1:1, group, meeting, channel) with last-message preview - fastest way to discover active chat IDs |
+| `teams_send_message` | Send a message (markdown); person `@[Name](mri)` or channel tag `@[Tag](tag:id)` via `teams_get_tags`; `replyToMessageId` for channel thread replies; `subject` for a new channel thread; `scheduleAt` (ISO 8601) to schedule; `contentType` (`auto`/`text`/`html`/`markdown`) to control formatting |
+| `teams_wait_for_reply` | Block (server-side poll, capped ~110s) until a new message arrives; idempotent `after`/`nextAfter` cursor; pair with `teams_send_message` |
 | `teams_get_me` | Get current user profile (email, name, ID) |
 | `teams_get_frequent_contacts` | Get frequently contacted people (for name resolution) |
 | `teams_search_people` | Search for people by name or email |
@@ -200,7 +202,7 @@ Session state and token cache files are protected by:
 | `teams_get_saved_messages` | Get list of saved/bookmarked messages with source references |
 | `teams_get_followed_threads` | Get list of followed threads with source references |
 | `teams_get_message` | Get a single message by ID with full content (any age); includes reactions and reaction summary |
-| `teams_get_thread` | Get messages from a conversation/thread; includes reactions; `threadRootId` scopes to one channel thread's replies; optional `since` (ISO 8601) for messages after a time |
+| `teams_get_thread` | Get messages from a conversation/thread; includes reactions; `threadRootId` scopes to one channel thread's replies; optional `since` (ISO 8601) for messages after a time; `fromUrl` to paste a Teams message deep link instead of a conversation ID |
 | `teams_find_channel` | Find channels by name (your teams + org-wide), shows membership |
 | `teams_get_tags` | List channel tags for a team (`teamId` from `teams_find_channel`) for tag @mentions |
 | `teams_get_chat` | Get conversation ID for 1:1 chat with a person |

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ The server uses your system's Chrome (macOS/Linux) or Edge (Windows) for authent
 |------|-------------|
 | `teams_search` | Search Teams messages with operators (`from:`, `sent:`, `in:`, `hasattachment:`, etc.) |
 | `teams_search_email` | Search emails in your mailbox (same auth as Teams — no extra login) |
+| `teams_list_chats` | List recent conversations (1:1, group, meeting, channel) with a last-message preview |
 | `teams_get_message` | Get a single message by ID with full content (any age); includes reactions |
-| `teams_get_thread` | Get messages from a conversation/thread; includes reactions; `threadRootId` scopes to one channel thread |
+| `teams_get_thread` | Get messages from a conversation/thread; includes reactions; `threadRootId` scopes to one channel thread; `fromUrl` accepts a Teams message deep link |
 | `teams_find_channel` | Find channels by name (your teams + org-wide discovery) |
 | `teams_get_activity` | Get activity feed (mentions, reactions, replies, notifications) |
 
@@ -85,8 +86,9 @@ The server uses your system's Chrome (macOS/Linux) or Edge (Windows) for authent
 
 | Tool | Description |
 |------|-------------|
-| `teams_send_message` | Send a message (default: self-chat/notes). Use `replyToMessageId` for thread replies |
-| `teams_edit_message` | Edit one of your own messages |
+| `teams_send_message` | Send a message (default: self-chat/notes). `replyToMessageId` for thread replies, `subject` for a new channel thread, `scheduleAt` to schedule, `contentType` (`auto`/`text`/`html`/`markdown`) to control formatting |
+| `teams_wait_for_reply` | Block until a new message arrives (server-side poll, capped ~110s); idempotent `after`/`nextAfter` cursor — pair with `teams_send_message` |
+| `teams_edit_message` | Edit one of your own messages (`contentType` supported) |
 | `teams_delete_message` | Delete one of your own messages (soft delete) |
 
 ### People & Contacts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "msteams-mcp",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "msteams-mcp",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msteams-mcp",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "MCP server for Microsoft Teams - search messages, send replies, manage favourites",
   "type": "module",
   "main": "dist/index.js",

--- a/src/api/chatsvc-api.ts
+++ b/src/api/chatsvc-api.ts
@@ -10,6 +10,7 @@
  * - chatsvc-reactions: add/remove emoji reactions
  * - chatsvc-virtual: saved messages, followed threads, save/unsave
  * - chatsvc-readstatus: consumption horizons, mark as read, unread counts
+ * - chatsvc-conversations: recent conversation list (chats, groups, channels)
  * - chatsvc-common: shared utilities (date formatting)
  */
 
@@ -19,4 +20,5 @@ export * from './chatsvc-activity.js';
 export * from './chatsvc-reactions.js';
 export * from './chatsvc-virtual.js';
 export * from './chatsvc-readstatus.js';
+export * from './chatsvc-conversations.js';
 export * from './chatsvc-common.js';

--- a/src/api/chatsvc-conversations.test.ts
+++ b/src/api/chatsvc-conversations.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for conversation-list parsing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseConversation } from './chatsvc-conversations.js';
+
+describe('parseConversation', () => {
+  it('parses a 1:1 chat with a last-message preview', () => {
+    const result = parseConversation({
+      id: '19:aaa_bbb@unq.gbl.spaces',
+      lastMessage: {
+        imdisplayname: 'Bob',
+        content: '<p>Hi there</p>',
+        originalarrivaltime: '2026-06-30T10:00:00Z',
+      },
+    });
+    expect(result).toEqual({
+      conversationId: '19:aaa_bbb@unq.gbl.spaces',
+      topic: '',
+      chatType: 'oneOnOne',
+      lastMessageTime: '2026-06-30T10:00:00Z',
+      lastMessageFrom: 'Bob',
+      lastMessagePreview: 'Hi there',
+    });
+  });
+
+  it('classifies channel, group and meeting conversation IDs', () => {
+    expect(parseConversation({ id: '19:x@thread.tacv2', threadProperties: { topic: 'General' } })?.chatType).toBe('channel');
+    expect(parseConversation({ id: '19:x@thread.v2' })?.chatType).toBe('group');
+    expect(parseConversation({ id: '19:meeting_x@thread.v2' })?.chatType).toBe('meeting');
+  });
+
+  it('uses the channel/group topic when present', () => {
+    const result = parseConversation({ id: '19:x@thread.tacv2', threadProperties: { topic: 'General' } });
+    expect(result?.topic).toBe('General');
+  });
+
+  it('truncates a long preview to 120 characters with an ellipsis', () => {
+    const long = 'a'.repeat(200);
+    const result = parseConversation({ id: '19:x@thread.v2', lastMessage: { content: long } });
+    expect(result?.lastMessagePreview.length).toBe(121); // 120 chars + ellipsis
+    expect(result?.lastMessagePreview.endsWith('…')).toBe(true);
+  });
+
+  it('returns null when the conversation has no id', () => {
+    expect(parseConversation({})).toBeNull();
+    expect(parseConversation({ id: '' })).toBeNull();
+  });
+
+  it('falls back to composetime when originalarrivaltime is absent', () => {
+    const result = parseConversation({
+      id: '19:x@thread.v2',
+      lastMessage: { composetime: '2026-06-30T09:00:00Z', content: 'hey' },
+    });
+    expect(result?.lastMessageTime).toBe('2026-06-30T09:00:00Z');
+  });
+});

--- a/src/api/chatsvc-conversations.ts
+++ b/src/api/chatsvc-conversations.ts
@@ -1,0 +1,119 @@
+/**
+ * Chat Service API - Conversation list.
+ *
+ * Lists the user's recent conversations (1:1 chats, group chats, meetings and
+ * channels) with a last-message preview, via the chatsvc conversations endpoint.
+ */
+
+import { httpRequest } from '../utils/http.js';
+import { CHATSVC_API, getSkypeAuthHeaders } from '../utils/api-config.js';
+import { type Result, ok } from '../types/result.js';
+import { requireMessageAuthWithConfig } from '../utils/auth-guards.js';
+import { stripHtml } from '../utils/parsers.js';
+import { DEFAULT_THREAD_LIMIT } from '../constants.js';
+
+/** Maximum length of a last-message preview before truncation. */
+const PREVIEW_MAX_LENGTH = 120;
+
+/** A summarised conversation as returned by the chat list. */
+export interface ChatSummary {
+  conversationId: string;
+  /** Channel/group topic, or empty for 1:1 chats. */
+  topic: string;
+  chatType: 'channel' | 'meeting' | 'group' | 'oneOnOne' | 'chat';
+  /** ISO timestamp of the last message, or empty if unknown. */
+  lastMessageTime: string;
+  /** Display name of the last message's sender. */
+  lastMessageFrom: string;
+  /** Plain-text preview of the last message, truncated. */
+  lastMessagePreview: string;
+}
+
+/** Result of listing conversations. */
+export interface GetConversationsResult {
+  conversations: ChatSummary[];
+}
+
+/** Classifies a conversation type from its ID. */
+function classifyChatType(id: string): ChatSummary['chatType'] {
+  if (id.includes('meeting_')) return 'meeting';
+  if (id.includes('@thread.tacv2')) return 'channel';
+  if (id.includes('@unq.gbl.spaces')) return 'oneOnOne';
+  if (id.includes('@thread.v2')) return 'group';
+  return 'chat';
+}
+
+/** Truncates a preview to {@link PREVIEW_MAX_LENGTH} characters, adding an ellipsis. */
+function truncatePreview(text: string): string {
+  if (text.length <= PREVIEW_MAX_LENGTH) return text;
+  return `${text.slice(0, PREVIEW_MAX_LENGTH)}…`;
+}
+
+/**
+ * Parses a raw chatsvc conversation into a {@link ChatSummary}, or null if it
+ * has no usable ID. Pure — no IO — so the field mapping and truncation are
+ * unit-testable against fixture JSON.
+ */
+export function parseConversation(raw: Record<string, unknown>): ChatSummary | null {
+  const id = typeof raw.id === 'string' ? raw.id : '';
+  if (!id) return null;
+
+  const threadProperties = (raw.threadProperties ?? {}) as Record<string, unknown>;
+  const topic = typeof threadProperties.topic === 'string' ? threadProperties.topic : '';
+
+  const lastMessage = (raw.lastMessage ?? {}) as Record<string, unknown>;
+  const lastMessageTime =
+    (typeof lastMessage.originalarrivaltime === 'string' && lastMessage.originalarrivaltime) ||
+    (typeof lastMessage.composetime === 'string' && lastMessage.composetime) ||
+    '';
+  const lastMessageFrom =
+    typeof lastMessage.imdisplayname === 'string' ? lastMessage.imdisplayname : '';
+  const rawContent = typeof lastMessage.content === 'string' ? lastMessage.content : '';
+
+  return {
+    conversationId: id,
+    topic,
+    chatType: classifyChatType(id),
+    lastMessageTime,
+    lastMessageFrom,
+    lastMessagePreview: truncatePreview(stripHtml(rawContent)),
+  };
+}
+
+/**
+ * Lists the user's recent conversations (chats, group chats, meetings and
+ * channels), newest activity first, capped at `limit`.
+ */
+export async function getConversations(
+  options: { limit?: number } = {}
+): Promise<Result<GetConversationsResult>> {
+  const authResult = requireMessageAuthWithConfig();
+  if (!authResult.ok) {
+    return authResult;
+  }
+  const { auth, region, baseUrl } = authResult.value;
+  const limit = options.limit ?? DEFAULT_THREAD_LIMIT;
+
+  const response = await httpRequest<{ conversations?: unknown[] }>(
+    CHATSVC_API.conversations(region, baseUrl),
+    {
+      method: 'GET',
+      headers: getSkypeAuthHeaders(auth.skypeToken, auth.authToken, baseUrl),
+    }
+  );
+
+  if (!response.ok) {
+    return response;
+  }
+
+  const raw = Array.isArray(response.value.data.conversations)
+    ? response.value.data.conversations
+    : [];
+
+  const conversations = raw
+    .map(c => parseConversation(c as Record<string, unknown>))
+    .filter((c): c is ChatSummary => c !== null)
+    .slice(0, limit);
+
+  return ok({ conversations });
+}

--- a/src/api/chatsvc-messaging.test.ts
+++ b/src/api/chatsvc-messaging.test.ts
@@ -10,7 +10,16 @@ import {
   buildMentionHtml,
   buildMentionsProperty,
   parseContentWithMentionsAndLinks,
+  resolveMessageContent,
+  parseScheduleTime,
+  buildScheduledDraftBody,
+  extractOneOnOneMemberIds,
+  buildOneOnOneThreadBody,
+  clampWaitParams,
+  selectNewMessages,
+  resolveWaitBaseline,
 } from './chatsvc-messaging.js';
+import { MAX_WAIT_SECONDS } from '../constants.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // buildMentionHtml
@@ -154,5 +163,223 @@ describe('parseContentWithMentionsAndLinks', () => {
     expect(mentions[0].mri).toBe('tag:abc');
     expect(html).toContain('<a href="https://example.com">docs</a>');
     expect(html).toContain('my-tag');
+  });
+
+  it('renders a mailto link', () => {
+    const { html } = parseContentWithMentionsAndLinks('Email [me](mailto:me@example.com) now');
+    expect(html).toContain('<a href="mailto:me@example.com">me</a>');
+  });
+
+  it('never emits a live href for a javascript: link', () => {
+    const { html } = parseContentWithMentionsAndLinks('[click](javascript:alert(1))');
+    expect(html).not.toContain('href="javascript:');
+  });
+});
+
+describe('resolveMessageContent', () => {
+  it('defaults to markdown conversion (backward compatible)', () => {
+    const r = resolveMessageContent('This is **bold**');
+    expect(r.messagetype).toBe('RichText/Html');
+    expect(r.content).toContain('<b>bold</b>');
+    expect(r.mentions).toHaveLength(0);
+  });
+
+  it('markdown mode extracts mentions', () => {
+    const r = resolveMessageContent('Hi @[Alice](8:orgid:abc)', 'markdown');
+    expect(r.messagetype).toBe('RichText/Html');
+    expect(r.mentions).toHaveLength(1);
+    expect(r.mentions[0].mri).toBe('8:orgid:abc');
+  });
+
+  it('text mode sends content verbatim with no conversion or mentions', () => {
+    const raw = 'Cost is 5*3*2 and use a_b_c @[A](8:orgid:x)';
+    const r = resolveMessageContent(raw, 'text');
+    expect(r.messagetype).toBe('Text');
+    expect(r.content).toBe(raw);
+    expect(r.mentions).toHaveLength(0);
+  });
+
+  it('html mode passes content through as RichText/Html without conversion', () => {
+    const r = resolveMessageContent('<p>hi <b>there</b></p>', 'html');
+    expect(r.messagetype).toBe('RichText/Html');
+    expect(r.content).toBe('<p>hi <b>there</b></p>');
+    expect(r.mentions).toHaveLength(0);
+  });
+
+  it('auto mode sends plain single-line text verbatim as Text', () => {
+    const r = resolveMessageContent('just plain text', 'auto');
+    expect(r.messagetype).toBe('Text');
+    expect(r.content).toBe('just plain text');
+  });
+
+  it('auto mode converts when markdown formatting is present', () => {
+    const r = resolveMessageContent('This is **bold**', 'auto');
+    expect(r.messagetype).toBe('RichText/Html');
+    expect(r.content).toContain('<b>bold</b>');
+  });
+
+  it('auto mode converts when a mention is present even without markdown', () => {
+    const r = resolveMessageContent('hi @[Alice](8:orgid:abc)', 'auto');
+    expect(r.messagetype).toBe('RichText/Html');
+    expect(r.mentions).toHaveLength(1);
+  });
+});
+
+describe('parseScheduleTime', () => {
+  const NOW = Date.parse('2026-01-01T00:00:00Z');
+
+  it('accepts an ISO 8601 UTC datetime in the future', () => {
+    const r = parseScheduleTime('2099-12-31T09:00:00Z', NOW);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.iso).toBe('2099-12-31T09:00:00.000Z');
+      expect(r.value.epochMs).toBe(Date.parse('2099-12-31T09:00:00Z'));
+    }
+  });
+
+  it('converts a datetime with offset to UTC', () => {
+    const r = parseScheduleTime('2099-12-31T09:00:00+05:00', NOW);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.iso).toBe('2099-12-31T04:00:00.000Z');
+  });
+
+  it('treats a timezone-less datetime as UTC', () => {
+    const r = parseScheduleTime('2099-12-31T09:00:00', NOW);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.iso).toBe('2099-12-31T09:00:00.000Z');
+  });
+
+  it('accepts a space separator without seconds (as UTC)', () => {
+    const r = parseScheduleTime('2099-12-31 09:00', NOW);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.iso).toBe('2099-12-31T09:00:00.000Z');
+  });
+
+  it('rejects a past datetime', () => {
+    const r = parseScheduleTime('2020-01-01T00:00:00Z', NOW);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects an unparseable datetime', () => {
+    expect(parseScheduleTime('not-a-date', NOW).ok).toBe(false);
+    expect(parseScheduleTime('', NOW).ok).toBe(false);
+  });
+});
+
+describe('buildScheduledDraftBody', () => {
+  it('builds a ScheduledDraft body with sendAt in epoch millis', () => {
+    const epochMs = Date.parse('2099-12-31T09:00:00Z');
+    const body = buildScheduledDraftBody({
+      conversationId: '19:abc@thread.v2',
+      content: 'Hello later',
+      messagetype: 'Text',
+      epochMs,
+      userMri: '8:orgid:me',
+      isoNow: '2026-01-01T00:00:00.000Z',
+      conversationLink: 'https://teams.microsoft.com/api/chatsvc/amer/v1/users/ME/conversations/19:abc@thread.v2',
+      clientMessageId: '12345',
+    });
+    expect(body.draftType).toBe('ScheduledDraft');
+    expect((body.draftDetails as Record<string, unknown>).sendAt).toBe(epochMs);
+    expect(body.innerThreadId).toBe('19:abc@thread.v2');
+    const message = body.message as Record<string, unknown>;
+    expect(message.content).toBe('Hello later');
+    expect(message.messagetype).toBe('Text');
+    expect(message.from).toBe('8:orgid:me');
+    expect((message.draftDetails as Record<string, unknown>).sendAt).toBe(epochMs);
+  });
+});
+
+describe('extractOneOnOneMemberIds', () => {
+  it('extracts both member object IDs from a 1:1 conversation ID', () => {
+    expect(extractOneOnOneMemberIds('19:aaa_bbb@unq.gbl.spaces')).toEqual(['aaa', 'bbb']);
+  });
+
+  it('returns null for non 1:1 conversation IDs', () => {
+    expect(extractOneOnOneMemberIds('19:xyz@thread.tacv2')).toBeNull();
+    expect(extractOneOnOneMemberIds('19:xyz@thread.v2')).toBeNull();
+  });
+
+  it('returns null for a malformed 1:1 ID missing a member', () => {
+    expect(extractOneOnOneMemberIds('19:aaa_@unq.gbl.spaces')).toBeNull();
+    expect(extractOneOnOneMemberIds('19:_bbb@unq.gbl.spaces')).toBeNull();
+  });
+});
+
+describe('buildOneOnOneThreadBody', () => {
+  it('builds a unique-roster thread body with both members as Admins', () => {
+    const body = buildOneOnOneThreadBody(['aaa', 'bbb']);
+    const members = body.members as Array<{ id: string; role: string }>;
+    expect(members).toHaveLength(2);
+    expect(members[0]).toEqual({ id: '8:orgid:aaa', role: 'Admin' });
+    expect(members[1]).toEqual({ id: '8:orgid:bbb', role: 'Admin' });
+    const props = body.properties as Record<string, string>;
+    expect(props.threadType).toBe('chat');
+    expect(props.uniquerosterthread).toBe('true');
+    expect(props.fixedRoster).toBe('true');
+  });
+});
+
+describe('clampWaitParams', () => {
+  it('leaves in-range values unchanged', () => {
+    expect(clampWaitParams(60, 5)).toEqual({ maxWait: 60, interval: 5 });
+  });
+
+  it('floors maxWait and interval to at least 1 second', () => {
+    expect(clampWaitParams(0, 0)).toEqual({ maxWait: 1, interval: 1 });
+  });
+
+  it('caps maxWait at MAX_WAIT_SECONDS', () => {
+    expect(clampWaitParams(99999, 10)).toEqual({ maxWait: MAX_WAIT_SECONDS, interval: 10 });
+  });
+
+  it('never lets the interval exceed the clamped maxWait', () => {
+    expect(clampWaitParams(30, 600)).toEqual({ maxWait: 30, interval: 30 });
+  });
+});
+
+describe('selectNewMessages', () => {
+  const msgs = [
+    { id: '100', isFromMe: false },
+    { id: '105', isFromMe: true },
+    { id: '110', isFromMe: false },
+    { id: 'abc', isFromMe: false }, // non-numeric id must be ignored
+  ];
+
+  it('returns only messages strictly newer than afterId, excluding own by default', () => {
+    const result = selectNewMessages(msgs, 100, false);
+    expect(result.map(m => m.id)).toEqual(['110']);
+  });
+
+  it('includes own messages when includeSelf is true, sorted ascending', () => {
+    const result = selectNewMessages(msgs, 100, true);
+    expect(result.map(m => m.id)).toEqual(['105', '110']);
+  });
+
+  it('returns empty when nothing is newer than afterId', () => {
+    expect(selectNewMessages(msgs, 110, true)).toEqual([]);
+  });
+});
+
+describe('resolveWaitBaseline', () => {
+  it('prefers the caller\'s own most recent message', () => {
+    const baseline = resolveWaitBaseline([
+      { id: '100', isFromMe: false },
+      { id: '90', isFromMe: true },
+      { id: '110', isFromMe: false },
+    ]);
+    expect(baseline).toBe(90);
+  });
+
+  it('falls back to the most recent message overall when the caller has not posted', () => {
+    const baseline = resolveWaitBaseline([
+      { id: '100', isFromMe: false },
+      { id: '110', isFromMe: false },
+    ]);
+    expect(baseline).toBe(110);
+  });
+
+  it('returns 0 for an empty thread', () => {
+    expect(resolveWaitBaseline([])).toBe(0);
   });
 });

--- a/src/api/chatsvc-messaging.ts
+++ b/src/api/chatsvc-messaging.ts
@@ -11,9 +11,9 @@ import { ErrorCode, createError } from '../types/errors.js';
 import { type Result, ok, err } from '../types/result.js';
 import { getUserDisplayName } from '../auth/token-extractor.js';
 import { requireMessageAuth, requireMessageAuthWithConfig, getTeamsBaseUrl, getTenantId } from '../utils/auth-guards.js';
-import { stripHtml, extractLinks, buildMessageLink, buildOneOnOneConversationId, extractObjectId, markdownToTeamsHtml, escapeHtmlChars, parseReactions, type ExtractedLink, type Reaction, type ReactionSummary } from '../utils/parsers.js';
+import { stripHtml, extractLinks, buildMessageLink, buildOneOnOneConversationId, extractObjectId, markdownToTeamsHtml, hasMarkdownFormatting, escapeHtmlChars, sanitizeLinkUrl, parseReactions, type ExtractedLink, type Reaction, type ReactionSummary } from '../utils/parsers.js';
 import { resolveNames } from './profile-api.js';
-import { SELF_CHAT_ID, MRI_ORGID_PREFIX } from '../constants.js';
+import { SELF_CHAT_ID, MRI_ORGID_PREFIX, DEFAULT_WAIT_SECONDS, DEFAULT_WAIT_INTERVAL_SECONDS, MAX_WAIT_SECONDS } from '../constants.js';
 import { formatHumanReadableDate } from './chatsvc-common.js';
 import type { RawChatsvcMessage, RawConversationResponse, RawCreateThreadResponse } from '../types/api-responses.js';
 
@@ -25,6 +25,8 @@ import type { RawChatsvcMessage, RawConversationResponse, RawCreateThreadRespons
 export interface SendMessageResult {
   messageId: string;
   timestamp?: number;
+  /** For scheduled messages: the ISO 8601 UTC time the message will be sent. */
+  scheduledFor?: string;
 }
 
 /** A message from a thread/conversation. */
@@ -103,6 +105,24 @@ export interface SendMessageOptions {
    * are part of the same flat conversation.
    */
   replyToMessageId?: string;
+  /**
+   * How to interpret the content. Defaults to `markdown` (convert markdown +
+   * @mentions + links to Teams HTML — the historical behaviour). Use `text` to
+   * send verbatim with no reinterpretation, `html` for caller-supplied Teams
+   * HTML, or `auto` to convert only when markdown/mention syntax is present.
+   */
+  contentType?: ContentType;
+  /**
+   * For channel posts: a thread subject/title. Starts a new titled thread.
+   * Ignored for 1:1/group chats (they have no per-message subject).
+   */
+  subject?: string;
+  /**
+   * Schedule the message for future delivery. ISO 8601 (e.g.
+   * "2026-04-11T09:00:00Z"); a timezone-less value is treated as UTC. Cannot be
+   * combined with mentions or a thread reply.
+   */
+  scheduleAt?: string;
 }
 
 /** Result of getting a 1:1 conversation. */
@@ -149,44 +169,93 @@ export async function sendMessage(
   }
   const { auth, region, baseUrl } = authResult.value;
 
-  const { replyToMessageId } = options;
+  const { replyToMessageId, contentType = 'markdown', subject, scheduleAt } = options;
   const displayName = getUserDisplayName() || 'User';
 
   const clientMessageId = crypto.randomUUID();
 
-  // Process content: handle mentions, links, and markdown formatting.
-  // Always convert through markdown→HTML pipeline (never pass user content through
-  // without sanitization, as Teams requires proper block-level wrapping like <p> tags)
-  const parsed = parseContentWithMentionsAndLinks(content);
-  const htmlContent = parsed.html;
-  const mentionsToSend = parsed.mentions;
+  // Resolve content per the requested content type (markdown by default).
+  const resolved = resolveMessageContent(content, contentType);
+
+  // Scheduled send goes through the chatsvc drafts API (same as the Teams web
+  // client). Drafts do not support mentions or thread replies.
+  if (scheduleAt) {
+    if (resolved.mentions.length > 0 || replyToMessageId) {
+      return err(createError(
+        ErrorCode.INVALID_INPUT,
+        'Scheduled messages cannot include @mentions or be thread replies. Remove scheduleAt, or the mention/replyToMessageId.'
+      ));
+    }
+    const parsedTime = parseScheduleTime(scheduleAt);
+    if (!parsedTime.ok) {
+      return parsedTime;
+    }
+    const draftBody = buildScheduledDraftBody({
+      conversationId,
+      content: resolved.content,
+      messagetype: resolved.messagetype,
+      epochMs: parsedTime.value.epochMs,
+      userMri: auth.userMri,
+      isoNow: new Date().toISOString(),
+      conversationLink: CHATSVC_API.conversation(region, conversationId, baseUrl),
+      clientMessageId,
+    });
+    const draftResponse = await httpRequest<unknown>(
+      CHATSVC_API.drafts(region, baseUrl),
+      {
+        method: 'POST',
+        headers: getMessagingHeaders(auth.skypeToken, auth.authToken, baseUrl),
+        body: JSON.stringify(draftBody),
+      }
+    );
+    if (!draftResponse.ok) {
+      return draftResponse;
+    }
+    return ok({ messageId: clientMessageId, scheduledFor: parsedTime.value.iso });
+  }
 
   // Build the message body
   const body: Record<string, unknown> = {
-    content: htmlContent,
-    messagetype: 'RichText/Html',
+    content: resolved.content,
+    messagetype: resolved.messagetype,
     contenttype: 'text',
     imdisplayname: displayName,
     clientmessageid: clientMessageId,
   };
 
-  // Add mentions property if mentions were found
-  if (mentionsToSend.length > 0) {
-    body.properties = {
-      mentions: buildMentionsProperty(mentionsToSend),
-    };
+  // Message properties: mentions and/or a channel thread subject.
+  const properties: Record<string, unknown> = {};
+  if (resolved.mentions.length > 0) {
+    properties.mentions = buildMentionsProperty(resolved.mentions);
+  }
+  if (subject && subject.trim()) {
+    properties.subject = subject.trim();
+  }
+  if (Object.keys(properties).length > 0) {
+    body.properties = properties;
   }
 
   const url = CHATSVC_API.messages(region, conversationId, replyToMessageId, baseUrl);
+  const requestInit = {
+    method: 'POST' as const,
+    headers: getMessagingHeaders(auth.skypeToken, auth.authToken, baseUrl),
+    body: JSON.stringify(body),
+  };
 
-  const response = await httpRequest<{ OriginalArrivalTime?: number }>(
-    url,
-    {
-      method: 'POST',
-      headers: getMessagingHeaders(auth.skypeToken, auth.authToken, baseUrl),
-      body: JSON.stringify(body),
+  let response = await httpRequest<{ OriginalArrivalTime?: number }>(url, requestInit);
+
+  // A 1:1 chat that has never been messaged has no chatsvc thread yet, so the
+  // deterministic @unq.gbl.spaces id 404s. Create the unique-roster thread (what
+  // the Teams client does when starting a new chat) and retry once.
+  if (!response.ok && response.error.code === ErrorCode.NOT_FOUND) {
+    const memberIds = extractOneOnOneMemberIds(conversationId);
+    if (memberIds) {
+      const created = await createOneOnOneThread(region, baseUrl, auth.skypeToken, auth.authToken, memberIds);
+      if (created.ok) {
+        response = await httpRequest<{ OriginalArrivalTime?: number }>(url, requestInit);
+      }
     }
-  );
+  }
 
   if (!response.ok) {
     return response;
@@ -196,6 +265,34 @@ export async function sendMessage(
     messageId: clientMessageId,
     timestamp: response.value.data.OriginalArrivalTime,
   });
+}
+
+/**
+ * Creates the unique-roster 1:1 thread for a `19:<a>_<b>@unq.gbl.spaces`
+ * conversation so the first message to a never-used 1:1 chat can be delivered.
+ */
+async function createOneOnOneThread(
+  region: string,
+  baseUrl: string,
+  skypeToken: string,
+  authToken: string,
+  memberIds: string[]
+): Promise<Result<void>> {
+  const response = await httpRequest<unknown>(
+    CHATSVC_API.createThread(region, baseUrl),
+    {
+      method: 'POST',
+      headers: {
+        ...getMessagingHeaders(skypeToken, authToken, baseUrl),
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify(buildOneOnOneThreadBody(memberIds)),
+    }
+  );
+  if (!response.ok) {
+    return response;
+  }
+  return ok(undefined);
 }
 
 /**
@@ -464,12 +561,14 @@ export async function getThreadMessages(
  *
  * @param conversationId - The conversation containing the message
  * @param messageId - The ID of the message to edit
- * @param newContent - New content (markdown; supports mentions like sendMessage)
+ * @param newContent - New content (markdown by default; supports mentions like sendMessage)
+ * @param contentType - How to interpret the content (default `markdown`)
  */
 export async function editMessage(
   conversationId: string,
   messageId: string,
-  newContent: string
+  newContent: string,
+  contentType: ContentType = 'markdown'
 ): Promise<Result<EditMessageResult>> {
   const authResult = requireMessageAuthWithConfig();
   if (!authResult.ok) {
@@ -478,24 +577,22 @@ export async function editMessage(
   const { auth, region, baseUrl } = authResult.value;
   const displayName = getUserDisplayName() || 'User';
 
-  // Same pipeline as sendMessage: markdown, @[mentions](mri), links, then mentions property.
-  const parsed = parseContentWithMentionsAndLinks(newContent);
-  const htmlContent = parsed.html;
-  const mentionsToSend = parsed.mentions;
+  // Same pipeline as sendMessage: resolve content per the requested type.
+  const resolved = resolveMessageContent(newContent, contentType);
 
   const body: Record<string, unknown> = {
     id: messageId,
     type: 'Message',
     conversationid: conversationId,
-    content: htmlContent,
-    messagetype: 'RichText/Html',
+    content: resolved.content,
+    messagetype: resolved.messagetype,
     contenttype: 'text',
     imdisplayname: displayName,
   };
 
-  if (mentionsToSend.length > 0) {
+  if (resolved.mentions.length > 0) {
     body.properties = {
-      mentions: buildMentionsProperty(mentionsToSend),
+      mentions: buildMentionsProperty(resolved.mentions),
     };
   }
 
@@ -966,7 +1063,7 @@ export function parseContentWithMentionsAndLinks(content: string): { html: strin
   // Patterns for mentions and links
   // Note: Link pattern uses [^)\s] to reject URLs with spaces
   const mentionPattern = /@\[([^\]]+)\]\(([^)]+)\)/g;
-  const linkPattern = /(?<!@)\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g;
+  const linkPattern = /(?<!@)\[([^\]]+)\]\((https?:\/\/[^)\s]+|mailto:[^)\s]+)\)/g;
   
   // Match type for tracking positions
   interface Match {
@@ -1026,7 +1123,7 @@ export function parseContentWithMentionsAndLinks(content: string): { html: strin
       mentionId++;
     } else {
       const safeText = escapeHtmlChars(m.text);
-      const safeUrl = m.target.replace(/"/g, '&quot;');
+      const safeUrl = sanitizeLinkUrl(m.target).replace(/"/g, '&quot;');
       html = `<a href="${safeUrl}">${safeText}</a>`;
     }
     placeholders.set(placeholder, html);
@@ -1046,6 +1143,347 @@ export function parseContentWithMentionsAndLinks(content: string): { html: strin
   }
   
   return { html: result, mentions };
+}
+
+/** How message content should be interpreted before sending. */
+export type ContentType = 'auto' | 'text' | 'html' | 'markdown';
+
+/** Content resolved into the shape the chatsvc/Graph message body expects. */
+export interface ResolvedContent {
+  /** The body content to send. */
+  content: string;
+  /** The wire message type: plain `Text` or `RichText/Html`. */
+  messagetype: 'Text' | 'RichText/Html';
+  /** Any @mentions extracted from the content (empty for text/html modes). */
+  mentions: Mention[];
+}
+
+/** Detects whether content contains @[mention](mri) or [text](url) markdown syntax. */
+function hasMentionOrLink(content: string): boolean {
+  return (
+    /@\[[^\]]+\]\([^)]+\)/.test(content) ||
+    /(?<!@)\[[^\]]+\]\((?:https?:\/\/|mailto:)[^)\s]+\)/.test(content)
+  );
+}
+
+/**
+ * Resolves outbound message content according to the requested content type.
+ *
+ * - `markdown` (default): convert markdown + @mentions + links to Teams HTML.
+ *   This preserves the historical behaviour where all content was converted.
+ * - `text`: send verbatim as plain text — no markdown, mention or link
+ *   processing. The escape hatch for content that should not be reinterpreted
+ *   (e.g. `5*3*2`, `a_b_c`).
+ * - `html`: caller-supplied Teams HTML, sent as `RichText/Html` unchanged.
+ * - `auto`: convert only when the content actually contains markdown formatting
+ *   or mention/link syntax; otherwise send plain text.
+ */
+export function resolveMessageContent(
+  content: string,
+  contentType: ContentType = 'markdown'
+): ResolvedContent {
+  switch (contentType) {
+    case 'text':
+      return { content, messagetype: 'Text', mentions: [] };
+    case 'html':
+      return { content, messagetype: 'RichText/Html', mentions: [] };
+    case 'auto':
+      if (!hasMarkdownFormatting(content) && !hasMentionOrLink(content)) {
+        return { content, messagetype: 'Text', mentions: [] };
+      }
+    // falls through to markdown conversion when formatting is detected
+    // eslint-disable-next-line no-fallthrough
+    case 'markdown':
+    default: {
+      const parsed = parseContentWithMentionsAndLinks(content);
+      return { content: parsed.html, messagetype: 'RichText/Html', mentions: parsed.mentions };
+    }
+  }
+}
+
+/**
+ * Parses and validates a schedule datetime for a scheduled message.
+ *
+ * Accepts ISO 8601 (with or without a timezone) and a space-separated
+ * `YYYY-MM-DD HH:mm[:ss]` form. A timezone-less value is treated as UTC (so
+ * results are deterministic regardless of the host clock). Rejects unparseable
+ * or past times. `now` is injectable for testing.
+ */
+export function parseScheduleTime(
+  input: string,
+  now: number = Date.now()
+): Result<{ iso: string; epochMs: number }> {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return err(createError(
+      ErrorCode.INVALID_INPUT,
+      'Schedule time cannot be empty. Use ISO 8601, e.g. "2026-04-11T09:00:00Z".'
+    ));
+  }
+  // Allow a space separator and treat a timezone-less datetime as UTC.
+  let normalized = trimmed.replace(' ', 'T');
+  const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/.test(normalized);
+  if (!hasTimezone) normalized += 'Z';
+
+  const epochMs = Date.parse(normalized);
+  if (Number.isNaN(epochMs)) {
+    return err(createError(
+      ErrorCode.INVALID_INPUT,
+      `Invalid schedule time: "${input}". Use ISO 8601, e.g. "2026-04-11T09:00:00Z".`
+    ));
+  }
+  if (epochMs <= now) {
+    return err(createError(
+      ErrorCode.INVALID_INPUT,
+      `Schedule time "${input}" is in the past.`
+    ));
+  }
+  return ok({ iso: new Date(epochMs).toISOString(), epochMs });
+}
+
+/**
+ * Builds the chatsvc `/drafts` request body for a scheduled message — the same
+ * mechanism the Teams web client uses. `sendAt` must be epoch milliseconds.
+ */
+export function buildScheduledDraftBody(opts: {
+  conversationId: string;
+  content: string;
+  messagetype: 'Text' | 'RichText/Html';
+  epochMs: number;
+  userMri: string;
+  isoNow: string;
+  conversationLink: string;
+  clientMessageId: string;
+}): Record<string, unknown> {
+  return {
+    draftDetails: { sendAt: opts.epochMs },
+    draftType: 'ScheduledDraft',
+    innerThreadId: opts.conversationId,
+    message: {
+      id: '-1',
+      type: 'Message',
+      conversationid: opts.conversationId,
+      conversationLink: opts.conversationLink,
+      from: opts.userMri,
+      fromUserId: opts.userMri,
+      composetime: opts.isoNow,
+      originalarrivaltime: opts.isoNow,
+      content: opts.content,
+      messagetype: opts.messagetype,
+      contenttype: 'Text',
+      imdisplayname: '',
+      clientmessageid: opts.clientMessageId,
+      properties: {
+        importance: '',
+        subject: '',
+        title: '',
+        cards: '[]',
+        links: '[]',
+        mentions: '[]',
+        onbehalfof: null,
+        files: '[]',
+        policyViolation: null,
+        draftId: opts.clientMessageId,
+      },
+      draftDetails: { sendAt: opts.epochMs },
+      threadtype: 'streamofdrafts',
+      innerThreadId: opts.conversationId,
+    },
+  };
+}
+
+/**
+ * Extracts the two member object IDs from a 1:1 conversation ID of the form
+ * `19:<a>_<b>@unq.gbl.spaces`. Returns null for any other conversation type or
+ * a malformed ID (so the caller only attempts thread creation for real 1:1s).
+ */
+export function extractOneOnOneMemberIds(conversationId: string): string[] | null {
+  const match = /^19:(.+)@unq\.gbl\.spaces$/.exec(conversationId);
+  if (!match) return null;
+  const parts = match[1].split('_');
+  if (parts.length !== 2 || parts.some(p => p.length === 0)) return null;
+  return parts;
+}
+
+/**
+ * Builds the `/v1/threads` body that creates the unique-roster 1:1 thread — what
+ * the Teams client does the first time you message someone. Both members are
+ * added as Admins with the fixed unique-roster properties.
+ */
+export function buildOneOnOneThreadBody(memberIds: string[]): Record<string, unknown> {
+  return {
+    members: memberIds.map(id => ({ id: `${MRI_ORGID_PREFIX}${id}`, role: 'Admin' })),
+    properties: {
+      threadType: 'chat',
+      fixedRoster: 'true',
+      uniquerosterthread: 'true',
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wait for reply
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Result of waiting for a new message in a conversation. */
+export interface WaitForReplyResult {
+  /** True if the wait timed out before any new message arrived. */
+  timedOut: boolean;
+  /** The baseline message ID the wait started from. */
+  after: string;
+  /** Resume cursor: pass as `after` to a follow-up wait to continue from here. */
+  nextAfter: string;
+  /** The new messages that arrived (oldest first), or empty on timeout. */
+  newMessages: ThreadMessage[];
+  /** How many poll iterations ran. */
+  polls: number;
+  /** How many seconds the wait blocked for. */
+  waitedSeconds: number;
+}
+
+/** Options for {@link waitForReply}. */
+export interface WaitForReplyOptions {
+  /** Only return messages newer than this message ID. Defaults to the caller's most recent message. */
+  after?: string;
+  /** Maximum seconds to block (clamped to MAX_WAIT_SECONDS). */
+  maxWaitSeconds?: number;
+  /** Seconds between polls. */
+  intervalSeconds?: number;
+  /** Include the caller's own messages in the result (default false). */
+  includeSelf?: boolean;
+  /** Messages fetched per poll (default 50). */
+  limit?: number;
+}
+
+/** Clamps the wait timing knobs into their sane range (pure, for testability). */
+export function clampWaitParams(
+  maxWaitSeconds: number,
+  intervalSeconds: number
+): { maxWait: number; interval: number } {
+  const maxWait = Math.min(Math.max(Math.floor(maxWaitSeconds), 1), MAX_WAIT_SECONDS);
+  const interval = Math.min(Math.max(Math.floor(intervalSeconds), 1), maxWait);
+  return { maxWait, interval };
+}
+
+/** Parses a numeric Teams message ID, or null if it is not a positive integer string. */
+function parseMessageId(id: string): number | null {
+  const n = Number(id);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Selects the messages strictly newer than `afterId`, oldest first. Excludes the
+ * caller's own messages unless `includeSelf` is set; ignores non-numeric IDs.
+ * Pure so the filter/sort semantics are unit-testable.
+ */
+export function selectNewMessages<T extends { id: string; isFromMe?: boolean }>(
+  messages: readonly T[],
+  afterId: number,
+  includeSelf: boolean
+): T[] {
+  return messages
+    .filter(m => {
+      const id = parseMessageId(m.id);
+      if (id === null || id <= afterId) return false;
+      if (!includeSelf && m.isFromMe) return false;
+      return true;
+    })
+    .sort((a, b) => (parseMessageId(a.id) ?? 0) - (parseMessageId(b.id) ?? 0));
+}
+
+/**
+ * Resolves the baseline message ID for a wait with no explicit `after`: the
+ * caller's own most recent message, else the most recent message overall, else
+ * 0 for an empty thread. Anchoring to the caller's own last message makes a wait
+ * restarted after a send idempotent without remembering the sent ID. Pure.
+ */
+export function resolveWaitBaseline(
+  messages: readonly { id: string; isFromMe?: boolean }[]
+): number {
+  let ownMax = 0;
+  let anyMax = 0;
+  for (const m of messages) {
+    const id = parseMessageId(m.id);
+    if (id === null) continue;
+    anyMax = Math.max(anyMax, id);
+    if (m.isFromMe) ownMax = Math.max(ownMax, id);
+  }
+  return ownMax > 0 ? ownMax : anyMax;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Blocks until a new message appears in a conversation, then returns only the
+ * new messages. Polls inside the call so a waiting agent makes a single tool
+ * call instead of a poll loop. Read-only and idempotent: it never posts, and the
+ * `after` baseline makes a restart resume from the same point without replaying.
+ *
+ * The block is capped at MAX_WAIT_SECONDS so an MCP client timeout never kills
+ * the call; on timeout it returns `timedOut: true` with `nextAfter` so the
+ * caller can simply call again to keep waiting.
+ */
+export async function waitForReply(
+  conversationId: string,
+  options: WaitForReplyOptions = {}
+): Promise<Result<WaitForReplyResult>> {
+  const { after, includeSelf = false, limit = 50 } = options;
+  const { maxWait, interval } = clampWaitParams(
+    options.maxWaitSeconds ?? DEFAULT_WAIT_SECONDS,
+    options.intervalSeconds ?? DEFAULT_WAIT_INTERVAL_SECONDS
+  );
+
+  // Resolve the idempotent baseline: an explicit `after` wins, otherwise anchor
+  // to the caller's own last message (fetched once).
+  let afterId: number;
+  if (after !== undefined) {
+    const parsed = parseMessageId(after);
+    if (parsed === null) {
+      return err(createError(
+        ErrorCode.INVALID_INPUT,
+        `'after' must be a numeric Teams message ID (got "${after}"). Use the id of a message from teams_get_thread.`
+      ));
+    }
+    afterId = parsed;
+  } else {
+    const initial = await getThreadMessages(conversationId, { limit, order: 'desc' });
+    if (!initial.ok) return initial;
+    afterId = resolveWaitBaseline(initial.value.messages);
+  }
+
+  const start = Date.now();
+  const deadline = start + maxWait * 1000;
+  let polls = 0;
+  let newMessages: ThreadMessage[] = [];
+
+  for (;;) {
+    polls++;
+    const page = await getThreadMessages(conversationId, { limit, order: 'asc' });
+    if (!page.ok) return page;
+    newMessages = selectNewMessages(page.value.messages, afterId, includeSelf);
+    if (newMessages.length > 0) break;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(interval * 1000, remaining));
+  }
+
+  // ponytail: advance the cursor to the last returned id. If more than `limit`
+  // messages arrive between two polls the surplus is re-fetched next call by id;
+  // a burst larger than `limit` could strand the oldest — upgrade to a
+  // backfill scan (like the Rust CLI) only if that proves to matter.
+  const nextAfter = newMessages.length > 0
+    ? newMessages[newMessages.length - 1].id
+    : String(afterId);
+  const waitedSeconds = Math.round((Date.now() - start) / 1000);
+
+  return ok({
+    timedOut: newMessages.length === 0,
+    after: String(afterId),
+    nextAfter,
+    newMessages,
+    polls,
+    waitedSeconds,
+  });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -120,6 +120,23 @@ export const DEFAULT_ACTIVITY_LIMIT = 50;
 export const MAX_ACTIVITY_LIMIT = 200;
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Wait for reply
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Default seconds to block in teams_wait_for_reply before timing out. */
+export const DEFAULT_WAIT_SECONDS = 60;
+
+/**
+ * Maximum seconds teams_wait_for_reply will block. Kept under common MCP client
+ * request timeouts (~2 minutes) so the tool returns a resumable timeout rather
+ * than having the whole call killed by the client.
+ */
+export const MAX_WAIT_SECONDS = 110;
+
+/** Default seconds between polls while waiting for a reply. */
+export const DEFAULT_WAIT_INTERVAL_SECONDS = 5;
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Calendar/Meetings
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/src/tools/message-tools.ts
+++ b/src/tools/message-tools.ts
@@ -22,9 +22,13 @@ import {
   removeReaction,
   getSavedMessages,
   getFollowedThreads,
+  getConversations,
+  waitForReply,
 } from '../api/chatsvc-api.js';
 import { getFavorites, addFavorite, removeFavorite, getCustomEmojis } from '../api/csa-api.js';
-import { SELF_CHAT_ID, MAX_THREAD_LIMIT, STANDARD_EMOJIS } from '../constants.js';
+import { parseTeamsMessageUrl } from '../utils/parsers.js';
+import { ErrorCode, createError } from '../types/errors.js';
+import { SELF_CHAT_ID, MAX_THREAD_LIMIT, DEFAULT_THREAD_LIMIT, MAX_WAIT_SECONDS, STANDARD_EMOJIS } from '../constants.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Schemas
@@ -34,6 +38,9 @@ export const SendMessageInputSchema = z.object({
   content: z.string().min(1, 'Message content cannot be empty'),
   conversationId: z.string().optional().default(SELF_CHAT_ID),
   replyToMessageId: z.string().optional(),
+  contentType: z.enum(['auto', 'text', 'html', 'markdown']).optional(),
+  subject: z.string().optional(),
+  scheduleAt: z.string().optional(),
 });
 
 export const FavoriteInputSchema = z.object({
@@ -59,6 +66,7 @@ export const EditMessageInputSchema = z.object({
   conversationId: z.string().min(1, 'Conversation ID cannot be empty'),
   messageId: z.string().min(1, 'Message ID cannot be empty'),
   content: z.string().min(1, 'Content cannot be empty'),
+  contentType: z.enum(['auto', 'text', 'html', 'markdown']).optional(),
 });
 
 export const DeleteMessageInputSchema = z.object({
@@ -109,19 +117,34 @@ export const GetMessageInputSchema = z.object({
   messageId: z.string().min(1, 'Message ID cannot be empty'),
 });
 
+export const ListChatsInputSchema = z.object({
+  limit: z.number().min(1).max(MAX_THREAD_LIMIT).optional().default(DEFAULT_THREAD_LIMIT),
+});
+
+export const WaitForReplyInputSchema = z.object({
+  conversationId: z.string().min(1).optional(),
+  fromUrl: z.string().min(1).optional(),
+  after: z.string().optional(),
+  maxWaitSeconds: z.number().min(1).max(MAX_WAIT_SECONDS).optional(),
+  intervalSeconds: z.number().min(1).optional(),
+  includeSelf: z.boolean().optional().default(false),
+}).refine(d => d.conversationId || d.fromUrl, {
+  message: 'Provide either conversationId or fromUrl',
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tool Definitions
 // ─────────────────────────────────────────────────────────────────────────────
 
 const sendMessageToolDefinition: Tool = {
   name: 'teams_send_message',
-  description: 'Send a message to a Teams conversation. Use markdown for formatting (not HTML): **bold**, *italic*, ~~strikethrough~~, `code`, ```code blocks```, lists, and newlines. Supports @mentions: people with @[Name](mri) (MRI from teams_search_people) and channel tags with @[TagName](tag:tagId) (IDs from teams_get_tags). Defaults to self-notes (48:notes). For channel thread replies, provide replyToMessageId.',
+  description: 'Send a message to a Teams conversation. Use markdown for formatting (not HTML): **bold**, *italic*, ~~strikethrough~~, `code`, ```code blocks```, lists, and newlines. Supports @mentions: people with @[Name](mri) (MRI from teams_search_people) and channel tags with @[TagName](tag:tagId) (IDs from teams_get_tags). Markdown links [text](url) support http(s) and mailto. Defaults to self-notes (48:notes). For channel thread replies, provide replyToMessageId. For a new channel thread with a title, provide subject. To schedule for later, provide scheduleAt (ISO 8601). Set contentType to "text" to send content verbatim without markdown interpretation.',
   inputSchema: {
     type: 'object',
     properties: {
       content: {
         type: 'string',
-        description: 'The message content in markdown (not HTML). Supports: **bold**, *italic*, ~~strikethrough~~, `inline code`, ```code blocks```, bullet lists (- item), numbered lists (1. item), and newlines. Do NOT send raw HTML tags. For people @mentions use @[DisplayName](mri) (MRI from teams_search_people). For channel tag @mentions use @[DisplayName](tag:tagId) (tag IDs from teams_get_tags). Markdown links [text](url) are supported.',
+        description: 'The message content in markdown (not HTML). Supports: **bold**, *italic*, ~~strikethrough~~, `inline code`, ```code blocks```, bullet lists (- item), numbered lists (1. item), and newlines. Do NOT send raw HTML tags (unless contentType is "html"). For people @mentions use @[DisplayName](mri) (MRI from teams_search_people). For channel tag @mentions use @[DisplayName](tag:tagId) (tag IDs from teams_get_tags). Markdown links [text](url) are supported (http/https/mailto).',
       },
       conversationId: {
         type: 'string',
@@ -130,6 +153,19 @@ const sendMessageToolDefinition: Tool = {
       replyToMessageId: {
         type: 'string',
         description: 'For channel thread replies: the message ID of the thread root. Use serverMessageId from teams_send_message, id from teams_get_thread, or messageId from teams_search.',
+      },
+      contentType: {
+        type: 'string',
+        enum: ['auto', 'text', 'html', 'markdown'],
+        description: 'How to interpret content. "markdown" (default): convert markdown + @mentions + links. "text": send verbatim with no interpretation (use for content with literal * _ ` that should not be formatted). "html": caller-supplied Teams HTML. "auto": convert only when markdown/mention syntax is present.',
+      },
+      subject: {
+        type: 'string',
+        description: 'For channel posts only: a thread subject/title. Starts a new titled thread. Ignored for 1:1/group chats.',
+      },
+      scheduleAt: {
+        type: 'string',
+        description: 'Schedule the message for future delivery. ISO 8601 (e.g. "2026-04-11T09:00:00Z"); a timezone-less value is treated as UTC. Cannot be combined with @mentions or replyToMessageId.',
       },
     },
     required: ['content'],
@@ -274,6 +310,11 @@ const editMessageToolDefinition: Tool = {
       content: {
         type: 'string',
         description: 'New content in markdown (not raw HTML): **bold**, *italic*, lists, code, @[Person](mri), @[Tag](tag:id), [text](url) — same as teams_send_message.',
+      },
+      contentType: {
+        type: 'string',
+        enum: ['auto', 'text', 'html', 'markdown'],
+        description: 'How to interpret content (default "markdown"). "text" sends verbatim without markdown interpretation; "html" is caller-supplied Teams HTML; "auto" converts only when markdown/mention syntax is present.',
       },
     },
     required: ['conversationId', 'messageId', 'content'],
@@ -458,6 +499,54 @@ const getMessageToolDefinition: Tool = {
   },
 };
 
+const listChatsToolDefinition: Tool = {
+  name: 'teams_list_chats',
+  description: 'List the user\'s recent conversations (1:1 chats, group chats, meetings and channels), newest activity first. Returns conversationId, chatType (oneOnOne/group/meeting/channel), topic, and a preview of the last message (sender, time, text). Use the returned conversationId with teams_get_thread to read messages or teams_send_message to reply. This is the fastest way to discover active chat IDs without a search.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      limit: {
+        type: 'number',
+        description: 'Maximum number of conversations to return (default: 50, max: 200).',
+      },
+    },
+  },
+};
+
+const waitForReplyToolDefinition: Tool = {
+  name: 'teams_wait_for_reply',
+  description: 'Block until a new message arrives in a conversation, then return only the new messages. Polls server-side so you make one tool call instead of repeatedly reading the thread. Read-only and idempotent: it never posts (pair it with teams_send_message), and re-running with after=nextAfter resumes from the same point. The block is capped (~110s) to stay under client timeouts; on timeout it returns timedOut=true with nextAfter — just call again to keep waiting. By default the baseline is your most recent message, so after a teams_send_message you can call this with no "after" to wait for the reply.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      conversationId: {
+        type: 'string',
+        description: 'The conversation ID to watch. Either this or fromUrl is required.',
+      },
+      fromUrl: {
+        type: 'string',
+        description: 'A Teams message deep link (https://teams.microsoft.com/l/message/...) to watch, parsed into the conversation ID. Use instead of conversationId.',
+      },
+      after: {
+        type: 'string',
+        description: 'Only return messages newer than this message ID (the resume cursor). Defaults to your most recent message in the thread. Pass the nextAfter value from a previous timed-out response to continue waiting.',
+      },
+      maxWaitSeconds: {
+        type: 'number',
+        description: 'Maximum seconds to block before returning a timed-out result (default 60, max 110).',
+      },
+      intervalSeconds: {
+        type: 'number',
+        description: 'Seconds between polls (default 5).',
+      },
+      includeSelf: {
+        type: 'boolean',
+        description: 'Include your own messages in the result (default false, since you are usually waiting for someone else\'s reply).',
+      },
+    },
+  },
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Handlers
 // ─────────────────────────────────────────────────────────────────────────────
@@ -468,10 +557,26 @@ async function handleSendMessage(
 ): Promise<ToolResult> {
   const result = await sendMessage(input.conversationId, input.content, {
     replyToMessageId: input.replyToMessageId,
+    contentType: input.contentType,
+    subject: input.subject,
+    scheduleAt: input.scheduleAt,
   });
 
   if (!result.ok) {
     return { success: false, error: result.error };
+  }
+
+  // Scheduled messages return a draft confirmation, not a sent message.
+  if (result.value.scheduledFor) {
+    return {
+      success: true,
+      data: {
+        messageId: result.value.messageId,
+        conversationId: input.conversationId,
+        scheduledFor: result.value.scheduledFor,
+        note: `Message scheduled for ${result.value.scheduledFor}. It appears as a scheduled draft in Teams until sent.`,
+      },
+    };
   }
 
   // The timestamp is the server-assigned ID - use this for reactions, threading, edits, etc.
@@ -643,7 +748,8 @@ async function handleEditMessage(
   const result = await editMessage(
     input.conversationId,
     input.messageId,
-    input.content
+    input.content,
+    input.contentType
   );
 
   if (!result.ok) {
@@ -964,6 +1070,81 @@ async function handleGetMessage(
   };
 }
 
+async function handleListChats(
+  input: z.infer<typeof ListChatsInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  const result = await getConversations({ limit: input.limit });
+
+  if (!result.ok) {
+    return { success: false, error: result.error };
+  }
+
+  return {
+    success: true,
+    data: {
+      count: result.value.conversations.length,
+      conversations: result.value.conversations,
+    },
+  };
+}
+
+async function handleWaitForReply(
+  input: z.infer<typeof WaitForReplyInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  let conversationId = input.conversationId;
+  if (input.fromUrl) {
+    const parsed = parseTeamsMessageUrl(input.fromUrl);
+    if (!parsed) {
+      return {
+        success: false,
+        error: createError(
+          ErrorCode.INVALID_INPUT,
+          `Could not parse a Teams message deep link from fromUrl: "${input.fromUrl}".`
+        ),
+      };
+    }
+    conversationId = parsed.conversationId;
+  }
+
+  if (!conversationId) {
+    return {
+      success: false,
+      error: createError(ErrorCode.INVALID_INPUT, 'Provide either conversationId or fromUrl.'),
+    };
+  }
+
+  const result = await waitForReply(conversationId, {
+    after: input.after,
+    maxWaitSeconds: input.maxWaitSeconds,
+    intervalSeconds: input.intervalSeconds,
+    includeSelf: input.includeSelf,
+  });
+
+  if (!result.ok) {
+    return { success: false, error: result.error };
+  }
+
+  const value = result.value;
+  return {
+    success: true,
+    data: {
+      timedOut: value.timedOut,
+      conversationId,
+      after: value.after,
+      nextAfter: value.nextAfter,
+      count: value.newMessages.length,
+      newMessages: value.newMessages,
+      polls: value.polls,
+      waitedSeconds: value.waitedSeconds,
+      note: value.timedOut
+        ? 'No new messages yet. Call teams_wait_for_reply again with after set to nextAfter to keep waiting.'
+        : undefined,
+    },
+  };
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Exports
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1082,6 +1263,18 @@ export const getMessageTool: RegisteredTool<typeof GetMessageInputSchema> = {
   handler: handleGetMessage,
 };
 
+export const listChatsTool: RegisteredTool<typeof ListChatsInputSchema> = {
+  definition: listChatsToolDefinition,
+  schema: ListChatsInputSchema,
+  handler: handleListChats,
+};
+
+export const waitForReplyTool: RegisteredTool<typeof WaitForReplyInputSchema> = {
+  definition: waitForReplyToolDefinition,
+  schema: WaitForReplyInputSchema,
+  handler: handleWaitForReply,
+};
+
 /** All message-related tools. */
 export const messageTools = [
   sendMessageTool,
@@ -1103,4 +1296,6 @@ export const messageTools = [
   getSavedMessagesTool,
   getFollowedThreadsTool,
   getMessageTool,
+  listChatsTool,
+  waitForReplyTool,
 ];

--- a/src/tools/search-tools.test.ts
+++ b/src/tools/search-tools.test.ts
@@ -17,11 +17,15 @@ import {
 // Local schema definitions to avoid circular imports through registry
 // These MUST match the actual schemas in search-tools.ts and message-tools.ts
 const GetThreadInputSchema = z.object({
-  conversationId: z.string().min(1, 'Conversation ID cannot be empty'),
+  conversationId: z.string().min(1, 'Conversation ID cannot be empty').optional(),
+  fromUrl: z.string().min(1).optional(),
+  threadRootId: z.string().optional(),
   limit: z.number().min(1).max(MAX_THREAD_LIMIT).optional().default(DEFAULT_THREAD_LIMIT),
   markRead: z.boolean().optional().default(false),
   order: z.enum(['asc', 'desc']).optional().default('desc'),
   since: z.string().optional(),
+}).refine(d => d.conversationId || d.fromUrl, {
+  message: 'Provide either conversationId or fromUrl',
 });
 
 const GetActivityInputSchema = z.object({
@@ -65,6 +69,18 @@ describe('GetThreadInputSchema', () => {
 
   it('rejects empty conversationId', () => {
     expect(() => GetThreadInputSchema.parse({ conversationId: '' })).toThrow();
+  });
+
+  it('accepts fromUrl instead of conversationId', () => {
+    const result = GetThreadInputSchema.parse({
+      fromUrl: 'https://teams.microsoft.com/l/message/19%3Aabc%40thread.tacv2/170',
+    });
+    expect(result.fromUrl).toContain('/l/message/');
+    expect(result.conversationId).toBeUndefined();
+  });
+
+  it('rejects when neither conversationId nor fromUrl is provided', () => {
+    expect(() => GetThreadInputSchema.parse({ limit: 10 })).toThrow();
   });
 
   it('rejects limit exceeding max', () => {

--- a/src/tools/search-tools.ts
+++ b/src/tools/search-tools.ts
@@ -8,6 +8,7 @@ import type { RegisteredTool, ToolContext, ToolResult } from './index.js';
 import { handleApiResult } from './index.js';
 import { searchMessages, searchEmails, searchChannels } from '../api/substrate-api.js';
 import { getThreadMessages, getConsumptionHorizon, markAsRead } from '../api/chatsvc-api.js';
+import { parseTeamsMessageUrl } from '../utils/parsers.js';
 import { ErrorCode, createError } from '../types/errors.js';
 import {
   DEFAULT_PAGE_SIZE,
@@ -30,12 +31,15 @@ export const SearchInputSchema = z.object({
 });
 
 export const GetThreadInputSchema = z.object({
-  conversationId: z.string().min(1, 'Conversation ID cannot be empty'),
+  conversationId: z.string().min(1, 'Conversation ID cannot be empty').optional(),
+  fromUrl: z.string().min(1).optional(),
   threadRootId: z.string().optional(),
   limit: z.number().min(1).max(MAX_THREAD_LIMIT).optional().default(DEFAULT_THREAD_LIMIT),
   markRead: z.boolean().optional().default(false),
   order: z.enum(['asc', 'desc']).optional().default('desc'),
   since: z.string().optional(),
+}).refine(d => d.conversationId || d.fromUrl, {
+  message: 'Provide either conversationId or fromUrl',
 });
 
 export const FindChannelInputSchema = z.object({
@@ -89,7 +93,11 @@ const getThreadToolDefinition: Tool = {
     properties: {
       conversationId: {
         type: 'string',
-        description: 'The conversation ID to get messages from (e.g., "19:abc@thread.tacv2" from search results)',
+        description: 'The conversation ID to get messages from (e.g., "19:abc@thread.tacv2" from search results). Either this or fromUrl is required.',
+      },
+      fromUrl: {
+        type: 'string',
+        description: 'A Teams message deep link (https://teams.microsoft.com/l/message/...). Parsed into the conversation ID automatically, so you can paste a link directly. If it points to a channel thread reply, the thread is scoped automatically. Use instead of conversationId.',
       },
       threadRootId: {
         type: 'string',
@@ -113,7 +121,6 @@ const getThreadToolDefinition: Tool = {
         description: 'ISO 8601 timestamp (e.g., "2026-02-26T00:00:00Z"). When provided, only returns messages after this time.',
       },
     },
-    required: ['conversationId'],
   },
 };
 
@@ -205,6 +212,32 @@ async function handleGetThread(
   input: z.infer<typeof GetThreadInputSchema>,
   _ctx: ToolContext
 ): Promise<ToolResult> {
+  // Resolve conversation and thread root from a deep link when fromUrl is given.
+  let conversationId = input.conversationId;
+  let threadRootId = input.threadRootId;
+  if (input.fromUrl) {
+    const parsed = parseTeamsMessageUrl(input.fromUrl);
+    if (!parsed) {
+      return {
+        success: false,
+        error: createError(
+          ErrorCode.INVALID_INPUT,
+          `Could not parse a Teams message deep link from fromUrl: "${input.fromUrl}". Expected a "/l/message/..." link.`
+        ),
+      };
+    }
+    conversationId = parsed.conversationId;
+    // A link into a channel thread reply carries the thread root as parentMessageId.
+    threadRootId = threadRootId ?? parsed.threadRootId;
+  }
+
+  if (!conversationId) {
+    return {
+      success: false,
+      error: createError(ErrorCode.INVALID_INPUT, 'Provide either conversationId or fromUrl.'),
+    };
+  }
+
   // Validate since parameter if provided
   let startTime: number | undefined;
   if (input.since) {
@@ -221,11 +254,11 @@ async function handleGetThread(
     startTime = parsed;
   }
 
-  const result = await getThreadMessages(input.conversationId, { 
+  const result = await getThreadMessages(conversationId, { 
     limit: input.limit,
     order: input.order,
     startTime,
-    replyToMessageId: input.threadRootId,
+    replyToMessageId: threadRootId,
   });
 
   if (!result.ok) {
@@ -236,7 +269,7 @@ async function handleGetThread(
   let unreadCount: number | undefined;
   let lastReadMessageId: string | undefined;
   
-  const horizonResult = await getConsumptionHorizon(input.conversationId);
+  const horizonResult = await getConsumptionHorizon(conversationId);
   if (horizonResult.ok) {
     lastReadMessageId = horizonResult.value.lastReadMessageId;
     
@@ -269,7 +302,7 @@ async function handleGetThread(
       ? result.value.messages[result.value.messages.length - 1]
       : result.value.messages[0];
     if (latestMessage) {
-      const markResult = await markAsRead(input.conversationId, latestMessage.id);
+      const markResult = await markAsRead(conversationId, latestMessage.id);
       markedAsRead = markResult.ok;
     }
   }

--- a/src/utils/api-config.ts
+++ b/src/utils/api-config.ts
@@ -115,6 +115,10 @@ export const CHATSVC_API = {
   /** List all recent conversations with inline properties. */
   conversations: (region: string, baseUrl = DEFAULT_TEAMS_BASE_URL) =>
     `${baseUrl}/api/chatsvc/${region}/v1/users/ME/conversations?view=msnp24Equivalent&pageSize=200`,
+
+  /** Create a scheduled draft (future-dated message). */
+  drafts: (region: string, baseUrl = DEFAULT_TEAMS_BASE_URL) =>
+    `${baseUrl}/api/chatsvc/${region}/v1/users/ME/drafts`,
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/utils/parsers-html.ts
+++ b/src/utils/parsers-html.ts
@@ -71,3 +71,39 @@ export function escapeHtmlChars(text: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
 }
+
+/**
+ * Extracts the lowercased URI scheme from a URL, or undefined if the URL is
+ * relative (RFC 3986 §3.1).
+ *
+ * A scheme is the run of letters/digits/`+`/`-`/`.` that starts with a letter
+ * and precedes the first `:` — but only when that `:` comes before any `/`, `?`
+ * or `#`, so `path/to:thing`, `foo?a=b:c` and `#a:b` are correctly treated as
+ * scheme-less relative URLs.
+ */
+function urlScheme(url: string): string | undefined {
+  const colon = url.indexOf(':');
+  if (colon <= 0) return undefined;
+  const scheme = url.slice(0, colon);
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*$/.test(scheme)) return undefined;
+  // A `/`, `?` or `#` before the colon means the colon is inside a relative URL.
+  if (/[/?#]/.test(url.slice(0, colon))) return undefined;
+  return scheme.toLowerCase();
+}
+
+/**
+ * Neutralises a link destination whose URL scheme is not on the allowlist.
+ *
+ * Only `http`, `https` and `mailto` (case-insensitive) are kept; any other
+ * scheme (`javascript:`, `data:`, `vbscript:`, `file:`, …) is rewritten to `#`
+ * so a link can never carry an executable scheme into a Teams-rendered message.
+ * Scheme-less URLs — relative paths and fragment-only links — carry no
+ * executable scheme and pass through unchanged.
+ */
+export function sanitizeLinkUrl(url: string): string {
+  const scheme = urlScheme(url);
+  if (scheme !== undefined && !['http', 'https', 'mailto'].includes(scheme)) {
+    return '#';
+  }
+  return url;
+}

--- a/src/utils/parsers-identifiers.ts
+++ b/src/utils/parsers-identifiers.ts
@@ -93,6 +93,58 @@ export function buildMessageLink(opts: MessageLinkOptions): string {
   return qs ? `${linkUrl}?${qs}` : linkUrl;
 }
 
+/** Result of parsing a Teams message deep link. */
+export interface ParsedMessageUrl {
+  /** The conversation/channel/chat ID (percent-decoded). */
+  conversationId: string;
+  /** The specific message ID from the URL path (percent-decoded). */
+  messageId?: string;
+  /** For channel threads: the thread root ID (the `parentMessageId` query param). */
+  threadRootId?: string;
+}
+
+/**
+ * Parses a Microsoft Teams message deep link into its conversation, message and
+ * thread-root IDs — the inverse of {@link buildMessageLink}.
+ *
+ * Handles the standard `.../l/message/{conversationId}/{messageId}?...` link
+ * Teams produces. The conversation and message IDs are percent-decoded. When a
+ * `parentMessageId` query param is present (a channel thread reply) it is
+ * returned as `threadRootId`, so callers can scope to that thread. Returns
+ * `null` for anything that is not a `/l/message/` deep link (e.g. channel links
+ * or non-Teams URLs).
+ */
+export function parseTeamsMessageUrl(url: string): ParsedMessageUrl | null {
+  const marker = '/l/message/';
+  const markerIndex = url.indexOf(marker);
+  if (markerIndex === -1) return null;
+
+  const rest = url.slice(markerIndex + marker.length);
+  const queryStart = rest.indexOf('?');
+  const path = queryStart === -1 ? rest : rest.slice(0, queryStart);
+  const query = queryStart === -1 ? '' : rest.slice(queryStart + 1);
+
+  const [rawConversationId = '', rawMessageId = ''] = path.split('/');
+  const conversationId = safeDecode(rawConversationId);
+  if (!conversationId) return null;
+
+  const messageId = safeDecode(rawMessageId) || undefined;
+
+  const parentMessageId = new URLSearchParams(query).get('parentMessageId');
+  const threadRootId = parentMessageId ? safeDecode(parentMessageId) : undefined;
+
+  return { conversationId, messageId, threadRootId: threadRootId || undefined };
+}
+
+/** Percent-decodes a URL component, returning the raw value if decoding fails. */
+function safeDecode(component: string): string {
+  try {
+    return decodeURIComponent(component);
+  } catch {
+    return component;
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Message Timestamps
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/utils/parsers.test.ts
+++ b/src/utils/parsers.test.ts
@@ -34,6 +34,8 @@ import {
   parseVirtualConversationMessage,
   hasMarkdownFormatting,
   parseReactions,
+  sanitizeLinkUrl,
+  parseTeamsMessageUrl,
 } from './parsers.js';
 import {
   searchResultItem,
@@ -1481,5 +1483,72 @@ describe('parseReactions', () => {
     expect(parseReactions({ properties: { emotions: 42 } } as unknown as RawMsg).reactions).toBeUndefined();
     expect(parseReactions({ properties: { emotions: [null, undefined, 'string'] } } as unknown as RawMsg).reactions).toBeUndefined();
     expect(parseReactions({ properties: { emotions: [{ noKey: true }] } } as unknown as RawMsg).reactions).toBeUndefined();
+  });
+});
+
+describe('sanitizeLinkUrl', () => {
+  it('keeps http, https and mailto URLs unchanged (case-insensitive)', () => {
+    expect(sanitizeLinkUrl('http://example.com')).toBe('http://example.com');
+    expect(sanitizeLinkUrl('https://example.com/path?q=1')).toBe('https://example.com/path?q=1');
+    expect(sanitizeLinkUrl('mailto:someone@example.com')).toBe('mailto:someone@example.com');
+    expect(sanitizeLinkUrl('HTTPS://Example.com')).toBe('HTTPS://Example.com');
+  });
+
+  it('neutralises dangerous schemes to #', () => {
+    expect(sanitizeLinkUrl('javascript:alert(1)')).toBe('#');
+    expect(sanitizeLinkUrl('JavaScript:alert(1)')).toBe('#');
+    expect(sanitizeLinkUrl('data:text/html,<script>')).toBe('#');
+    expect(sanitizeLinkUrl('vbscript:msgbox')).toBe('#');
+    expect(sanitizeLinkUrl('file:///etc/passwd')).toBe('#');
+  });
+
+  it('leaves scheme-less relative and fragment URLs unchanged', () => {
+    expect(sanitizeLinkUrl('/relative/path')).toBe('/relative/path');
+    expect(sanitizeLinkUrl('page.html')).toBe('page.html');
+    expect(sanitizeLinkUrl('#section')).toBe('#section');
+    // A colon after a path/query delimiter is not a scheme (RFC 3986).
+    expect(sanitizeLinkUrl('path/to:thing')).toBe('path/to:thing');
+  });
+});
+
+describe('parseTeamsMessageUrl', () => {
+  it('parses a channel thread deep link, preferring parentMessageId as the thread root', () => {
+    const url =
+      'https://teams.microsoft.com/l/message/19%3Axxx%40thread.tacv2/170?tenantId=t&parentMessageId=169';
+    const result = parseTeamsMessageUrl(url);
+    expect(result).toEqual({
+      conversationId: '19:xxx@thread.tacv2',
+      messageId: '170',
+      threadRootId: '169',
+    });
+  });
+
+  it('parses a link without parentMessageId (top-level post has no thread root)', () => {
+    const url = 'https://teams.microsoft.com/l/message/19%3Axxx%40thread.tacv2/170';
+    const result = parseTeamsMessageUrl(url);
+    expect(result).toEqual({
+      conversationId: '19:xxx@thread.tacv2',
+      messageId: '170',
+      threadRootId: undefined,
+    });
+  });
+
+  it('parses a 1:1 chat message link with a context query param', () => {
+    const url =
+      'https://teams.microsoft.com/l/message/19%3Aabc_def%40unq.gbl.spaces/1700000000000?context=%7B%22contextType%22%3A%22chat%22%7D';
+    const result = parseTeamsMessageUrl(url);
+    expect(result?.conversationId).toBe('19:abc_def@unq.gbl.spaces');
+    expect(result?.messageId).toBe('1700000000000');
+    expect(result?.threadRootId).toBeUndefined();
+  });
+
+  it('returns null for URLs that are not message deep links', () => {
+    expect(parseTeamsMessageUrl('https://teams.microsoft.com/l/channel/19%3Axxx/General')).toBeNull();
+    expect(parseTeamsMessageUrl('https://example.com/foo')).toBeNull();
+    expect(parseTeamsMessageUrl('not a url')).toBeNull();
+  });
+
+  it('returns null when the channel id segment is empty', () => {
+    expect(parseTeamsMessageUrl('https://teams.microsoft.com/l/message//170')).toBeNull();
   });
 });

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -13,11 +13,12 @@
  * - parsers-reactions: Emoji reaction parsing from raw messages
  */
 
-export { extractLinks, stripHtml, escapeHtmlChars, type ExtractedLink } from './parsers-html.js';
+export { extractLinks, stripHtml, escapeHtmlChars, sanitizeLinkUrl, type ExtractedLink } from './parsers-html.js';
 export { markdownToTeamsHtml, hasMarkdownFormatting } from './parsers-markdown.js';
 export {
   getConversationType,
   buildMessageLink,
+  parseTeamsMessageUrl,
   extractMessageTimestamp,
   extractActivityTimestamp,
   decodeBase64Guid,
@@ -25,6 +26,7 @@ export {
   buildOneOnOneConversationId,
   type MessageLinkOptions,
   type LinkContext,
+  type ParsedMessageUrl,
 } from './parsers-identifiers.js';
 export {
   parseV2Result,


### PR DESCRIPTION
## Summary

Ports a set of capabilities proven out in our Rust Teams CLI back into the MCP. Everything here uses **chatsvc or local logic only — no Microsoft Graph API**, preserving the MCP's key USP (no Azure app registration / no extra auth pipeline).

## New tools

- **`teams_list_chats`** — recent conversations (1:1, group, meeting, channel), newest first, with a last-message preview. The fastest way to discover active chat IDs (fills a previously-documented "no chat list API" limitation).
- **`teams_wait_for_reply`** — blocks server-side until a new message arrives, returning only the new messages. Idempotent `after`/`nextAfter` cursor; capped at ~110s so an MCP client timeout never kills the call (returns `timedOut: true` with a resume cursor instead). Pair with `teams_send_message`.

## Enhancements to existing tools

- **`teams_send_message`**
  - `scheduleAt` (ISO 8601) — schedule via the chatsvc drafts API (same mechanism as the Teams web client).
  - `subject` — start a titled channel thread.
  - `contentType` (`auto`/`text`/`html`/`markdown`) — control formatting; `text` is an escape hatch for content like `5*3*2` or `a_b_c` that should not be reinterpreted. Default `markdown` keeps existing behaviour.
  - **1:1 reliability fix** — the first message to a never-used 1:1 chat previously 404'd (the deterministic `@unq.gbl.spaces` id has no thread yet). Now auto-creates the unique-roster thread and retries once, exactly like the Teams client.
- **`teams_get_thread`** (and `teams_wait_for_reply`) — `fromUrl` accepts a Teams message deep link (`/l/message/...`) instead of a conversation ID; channel-thread links auto-scope to the thread root.
- **Markdown links** — scheme allowlist neutralises `javascript:`/`data:` links, and `mailto:` links are now supported.

## Testing

- **+46 unit tests** (383 total), all TDD'd red-first against pure functions: deep-link parsing, link-scheme sanitising, content-type resolution, schedule parsing, scheduled-draft / 1:1-thread body builders, conversation parsing, and the wait cursor/baseline logic.
- `npm run typecheck`, `npm run lint`, `npm test`, `npm run build` all pass.
- MCP protocol layer verified: 35 tools registered (was 33).

## Version

Minor bump to **0.25.0**.

## Deliberate simplification

`waitForReply` advances its resume cursor to the last returned message id rather than porting the Rust CLI's full backfill scan. A burst larger than the page size (50) between two polls could re-order the oldest; flagged with a `ponytail:` comment and easily upgraded if it proves to matter.
