### PR TITLE
fix: numeric clientMessageId so Teams accepts sent messages (0.25.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "msteams-mcp",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "msteams-mcp",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msteams-mcp",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "MCP server for Microsoft Teams - search messages, send replies, manage favourites",
   "type": "module",
   "main": "dist/index.js",

--- a/src/api/chatsvc-messaging.test.ts
+++ b/src/api/chatsvc-messaging.test.ts
@@ -18,6 +18,7 @@ import {
   clampWaitParams,
   selectNewMessages,
   resolveWaitBaseline,
+  generateClientMessageId,
 } from './chatsvc-messaging.js';
 import { MAX_WAIT_SECONDS } from '../constants.js';
 
@@ -358,6 +359,21 @@ describe('selectNewMessages', () => {
 
   it('returns empty when nothing is newer than afterId', () => {
     expect(selectNewMessages(msgs, 110, true)).toEqual([]);
+  });
+});
+
+describe('generateClientMessageId', () => {
+  it('returns a numeric string (Teams rejects non-numeric client message IDs)', () => {
+    // Regression: a UUID (crypto.randomUUID) is rejected by Teams with
+    // "StoreInvalidInput - ClientMessageId must be a number in string format".
+    const id = generateClientMessageId();
+    expect(id).toMatch(/^\d+$/);
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('produces distinct IDs across rapid calls', () => {
+    const ids = new Set(Array.from({ length: 50 }, () => generateClientMessageId()));
+    expect(ids.size).toBeGreaterThan(1);
   });
 });
 

--- a/src/api/chatsvc-messaging.ts
+++ b/src/api/chatsvc-messaging.ts
@@ -149,6 +149,20 @@ export interface CreateGroupChatResult {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * Generates a Teams client message ID.
+ *
+ * Teams requires this to be "a number in string format" — a UUID is rejected
+ * with `StoreInvalidInput - ClientMessageId must be a number in string format`.
+ * This mirrors the Teams web client's large random integer: current time in
+ * milliseconds plus 6 random digits, keeping IDs numeric and unique even for
+ * rapid successive sends.
+ */
+export function generateClientMessageId(): string {
+  const random = Math.floor(Math.random() * 1_000_000).toString().padStart(6, '0');
+  return `${Date.now()}${random}`;
+}
+
+/**
  * Sends a message to a Teams conversation.
  * 
  * For channels, you can either:
@@ -172,7 +186,7 @@ export async function sendMessage(
   const { replyToMessageId, contentType = 'markdown', subject, scheduleAt } = options;
   const displayName = getUserDisplayName() || 'User';
 
-  const clientMessageId = crypto.randomUUID();
+  const clientMessageId = generateClientMessageId();
 
   // Resolve content per the requested content type (markdown by default).
   const resolved = resolveMessageContent(content, contentType);


### PR DESCRIPTION
## Summary

Fixes a send-blocking bug: `teams_send_message` (and scheduled sends) built `clientmessageid` with `crypto.randomUUID()`, which Teams rejects:

```
StoreInvalidInput - ClientMessageId must be a number in string format.
```

Every attempt to post a new message failed before formatting was ever exercised. Introduced earlier in `0db408c` and shipped in **0.25.0**.

## Scope

- **Broken (now fixed):** `teams_send_message` immediate + scheduled sends — the only two paths that put a `clientmessageid` on the wire.
- **Unaffected:** `teams_edit_message`, reactions, `teams_mark_read`, group-chat creation, and all read tools never sent a client id, so they worked throughout.

## Fix

- New `generateClientMessageId()` returns a numeric string (`Date.now()` + 6 random digits, mirroring the Teams web client's large random integer — unique even for rapid sends).
- `sendMessage` uses it for both normal and scheduled-draft bodies.
- Regression test asserts the id matches `/^\d+$/` — exactly what would have caught the original bug.

## Verification

`npm run typecheck`, `npm run lint`, `npm test` (385 passing, +2), and `npm run build` all green.

## Version

Patch bump to **0.25.1**.

After merge: publish `0.25.1`, and consider `npm deprecate msteams-mcp@0.25.0 "broken message send (non-numeric ClientMessageId); upgrade to 0.25.1"`.
