### PR TITLE
fix: prefer SubstrateSearch origin for Teams session

### DIFF
--- a/docs/SESSION-DATA-REFERENCE.md
+++ b/docs/SESSION-DATA-REFERENCE.md
@@ -384,21 +384,28 @@ const teamsBaseUrl = `${url.protocol}//${url.host}`; // "https://teams.microsoft
 
 ### Finding the Right Origin
 
+Sessions may include both `teams.microsoft.com` and `teams.cloud.microsoft`.
+SubstrateSearch tokens (email/search) are often only on the cloud host after
+the New Teams migration — prefer that origin when a SubstrateSearch token is present.
+
 ```typescript
 const TEAMS_ORIGINS = [
+  'https://teams.cloud.microsoft',
   'https://teams.microsoft.com',
   'https://teams.microsoft.us',
   'https://dod.teams.microsoft.us',
-  'https://teams.cloud.microsoft',
 ];
 
 function getTeamsOrigin(state: SessionState) {
+  // Prefer origin with SubstrateSearch token, then TEAMS_ORIGINS order
+  const withSubstrate = state.origins.find(/* has SubstrateSearch MSAL entry */);
+  if (withSubstrate) return withSubstrate;
+
   for (const knownOrigin of TEAMS_ORIGINS) {
     const origin = state.origins.find(o => o.origin === knownOrigin);
     if (origin) return origin;
   }
-  // Fallback: find any origin containing 'teams.microsoft'
-  return state.origins.find(o => 
+  return state.origins.find(o =>
     o.origin.includes('teams.microsoft') || o.origin.includes('teams.cloud')
   ) ?? null;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "zod": "~3.23.0"
       },
       "bin": {
+        "msteams": "dist/cli.js",
         "msteams-mcp": "dist/index.js"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "msteams-mcp",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "msteams-mcp",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msteams-mcp",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "MCP server for Microsoft Teams - search messages, send replies, manage favourites",
   "type": "module",
   "main": "dist/index.js",

--- a/src/auth/session-store.test.ts
+++ b/src/auth/session-store.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for getTeamsOrigin — especially New Teams (teams.cloud.microsoft)
+ * SubstrateSearch token selection when multiple origins are present.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getTeamsOrigin, type SessionState } from './session-store.js';
+
+function makeOrigin(
+  origin: string,
+  localStorage: SessionState['origins'][number]['localStorage'] = []
+): SessionState['origins'][number] {
+  return { origin, localStorage };
+}
+
+function makeSubstrateEntry(target = 'https://substrate.office.com/SubstrateSearch-Internal.ReadWrite') {
+  return {
+    name: 'msal-substrate-token',
+    value: JSON.stringify({
+      credentialType: 'AccessToken',
+      target,
+      // JWT-shaped secret (header.payload.sig) — extractor only checks prefix
+      secret: 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.sig',
+    }),
+  };
+}
+
+function makeChatSvcEntry() {
+  return {
+    name: 'msal-chatsvc-token',
+    value: JSON.stringify({
+      credentialType: 'AccessToken',
+      target: 'https://chatsvcagg.teams.microsoft.com/.default',
+      secret: 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJjaGF0In0.sig',
+    }),
+  };
+}
+
+describe('getTeamsOrigin', () => {
+  it('prefers the origin that holds a SubstrateSearch token', () => {
+    const state: SessionState = {
+      cookies: [],
+      origins: [
+        makeOrigin('https://teams.microsoft.com', [makeChatSvcEntry()]),
+        makeOrigin('https://teams.cloud.microsoft', [makeSubstrateEntry()]),
+      ],
+    };
+
+    const chosen = getTeamsOrigin(state);
+    expect(chosen?.origin).toBe('https://teams.cloud.microsoft');
+  });
+
+  it('falls back to teams.cloud.microsoft when no Substrate token exists', () => {
+    const state: SessionState = {
+      cookies: [],
+      origins: [
+        makeOrigin('https://teams.microsoft.com', [makeChatSvcEntry()]),
+        makeOrigin('https://teams.cloud.microsoft', [makeChatSvcEntry()]),
+      ],
+    };
+
+    const chosen = getTeamsOrigin(state);
+    expect(chosen?.origin).toBe('https://teams.cloud.microsoft');
+  });
+
+  it('returns teams.microsoft.com when it is the only known origin', () => {
+    const state: SessionState = {
+      cookies: [],
+      origins: [makeOrigin('https://teams.microsoft.com', [makeChatSvcEntry()])],
+    };
+
+    const chosen = getTeamsOrigin(state);
+    expect(chosen?.origin).toBe('https://teams.microsoft.com');
+  });
+
+  it('returns null when no Teams origins are present', () => {
+    const state: SessionState = {
+      cookies: [],
+      origins: [makeOrigin('https://login.microsoftonline.com', [])],
+    };
+
+    expect(getTeamsOrigin(state)).toBeNull();
+  });
+});

--- a/src/auth/session-store.ts
+++ b/src/auth/session-store.ts
@@ -258,27 +258,58 @@ export function clearTokenCache(): void {
  * Used to find the correct origin in session state.
  */
 const TEAMS_ORIGINS = [
-  'https://teams.microsoft.com',   // Commercial
+  'https://teams.cloud.microsoft', // New Teams URL (often holds SubstrateSearch tokens)
+  'https://teams.microsoft.com',   // Commercial legacy
   'https://teams.microsoft.us',    // GCC-High
   'https://dod.teams.microsoft.us', // DoD
-  'https://teams.cloud.microsoft', // New Teams URL
 ];
+
+/**
+ * Returns true if localStorage has a SubstrateSearch MSAL token entry.
+ */
+function hasSubstrateSearchToken(
+  localStorage: SessionState['origins'][number]['localStorage'] | undefined
+): boolean {
+  for (const item of localStorage ?? []) {
+    try {
+      const entry = JSON.parse(item.value) as { target?: string; secret?: string };
+      if (
+        entry.target?.includes('SubstrateSearch') &&
+        typeof entry.secret === 'string' &&
+        entry.secret.startsWith('ey')
+      ) {
+        return true;
+      }
+    } catch {
+      // ignore non-JSON localStorage values
+    }
+  }
+  return false;
+}
 
 /**
  * Gets the Teams origin from session state.
  * Checks multiple known Teams domains to support government clouds.
+ *
+ * Prefers an origin that has a SubstrateSearch token so Outlook/email and
+ * Substrate search keep working when both teams.cloud.microsoft and
+ * teams.microsoft.com are present in the saved session (common after the
+ * New Teams host migration).
  */
 export function getTeamsOrigin(state: SessionState): SessionState['origins'][number] | null {
   if (!state.origins) return null;
-  
+
+  const withSubstrate = state.origins.find(o => hasSubstrateSearchToken(o.localStorage));
+  if (withSubstrate) return withSubstrate;
+
   // Try known Teams origins in priority order
   for (const knownOrigin of TEAMS_ORIGINS) {
     const origin = state.origins.find(o => o.origin === knownOrigin);
     if (origin) return origin;
   }
-  
+
   // Fallback: find any origin containing 'teams.microsoft'
-  return state.origins.find(o => 
+  return state.origins.find(o =>
     o.origin.includes('teams.microsoft') || o.origin.includes('teams.cloud')
   ) ?? null;
 }


### PR DESCRIPTION
## Summary
- Prefer the session origin that holds a `SubstrateSearch` MSAL token when selecting Teams storage (`getTeamsOrigin`).
- Rank `teams.cloud.microsoft` ahead of legacy `teams.microsoft.com`, matching where New Teams now keeps Substrate/email tokens.
- Add unit coverage for the dual-origin case; update session-data docs.

This addresses recent reports where messaging worked but Substrate (email/search) looked missing: both origins were present, and the legacy host was chosen first despite having no Substrate scopes.

## Test plan
- [x] `npx vitest run src/auth/session-store.test.ts`
- [ ] Re-login / use an existing New Teams session and confirm `teams_status` shows `directApi.available: true`
- [ ] `msteams teams_search_email --query 'is:unread'` returns results


Made with [Cursor](https://cursor.com)