### PR TITLE
feat: file attachment support via Graph API upload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,7 @@ Different Teams APIs use different authentication mechanisms:
 | **Calendar** (mt/part/calendarView) | Skype Spaces token (`api.spaces.skype.com` scope) + `skypetoken_asm` | `auth/token-extractor` | `extractSkypeSpacesToken()` |
 | **Transcripts** (Substrate WorkingSetFiles) | Same JWT as Search (Substrate scope) + `Prefer` header | `auth/token-extractor` | `getValidSubstrateToken()` |
 | **Files** (Substrate AllFiles) | Same JWT as Search (Substrate scope) + message auth for user MRI | `auth/token-extractor` | `getValidSubstrateToken()` + `extractMessageAuth()` |
+| **File Upload** (Microsoft Graph) | Graph API token (`graph.microsoft.com` scope, Files.ReadWrite.All) | `auth/token-extractor` | `getValidGraphToken()` |
 | **Profiles** (mt/part fetchShortProfile) | Skype Spaces token (`api.spaces.skype.com` scope) + `skypetoken_asm` | `auth/token-extractor` | `requireSkypeSpacesAuthWithConfig()` |
 
 **Important**: The CSA API (for favorites) requires a GET request to retrieve data, POST only for modifications. The Substrate suggestions API requires `cvid` and `logicalId` correlation IDs in the request body.
@@ -187,7 +188,7 @@ Session state and token cache files are protected by:
 | `teams_search` | Search Teams messages with query operators, supports pagination |
 | `teams_search_email` | Search emails in user's mailbox (same Substrate token as Teams search) |
 | `teams_list_chats` | List recent conversations (1:1, group, meeting, channel) with last-message preview - fastest way to discover active chat IDs |
-| `teams_send_message` | Send a message (markdown); person `@[Name](mri)` or channel tag `@[Tag](tag:id)` via `teams_get_tags`; `replyToMessageId` for channel thread replies; `subject` for a new channel thread; `scheduleAt` (ISO 8601) to schedule; `contentType` (`auto`/`text`/`html`/`markdown`) to control formatting |
+| `teams_send_message` | Send a message (markdown); person `@[Name](mri)` or channel tag `@[Tag](tag:id)` via `teams_get_tags`; `replyToMessageId` for channel thread replies; `subject` for a new channel thread; `scheduleAt` (ISO 8601) to schedule; `contentType` (`auto`/`text`/`html`/`markdown`) to control formatting; `attachments` (array of `{ filePath }`) to upload and attach local files |
 | `teams_wait_for_reply` | Block (server-side poll, capped ~110s) until a new message arrives; idempotent `after`/`nextAfter` cursor; pair with `teams_send_message` |
 | `teams_get_me` | Get current user profile (email, name, ID) |
 | `teams_get_frequent_contacts` | Get frequently contacted people (for name resolution) |
@@ -219,6 +220,7 @@ Session state and token cache files are protected by:
 | `teams_get_meetings` | Get meetings from calendar (upcoming/past by date range) |
 | `teams_get_transcript` | Get meeting transcript (requires threadId from teams_get_meetings) |
 | `teams_get_shared_files` | Get files and links shared in a conversation |
+| `teams_upload_file` | Upload a local file to OneDrive "Microsoft Teams Chat Files" folder; returns metadata + `filesProperty` for use with `teams_send_message` attachments |
 
 ### Design Philosophy
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ See [CLI Usage](#cli-usage) for commands.
 | Tool | Description |
 |------|-------------|
 | `teams_get_shared_files` | Get files and links shared in a conversation (supports pagination) |
+| `teams_upload_file` | Upload a local file to OneDrive and attach to messages |
 
 Returns both files (name, extension, URL, size) and links (URL, title), along with who shared each item. Works for channels, group chats, 1:1 chats, and meeting chats.
 

--- a/src/api/chatsvc-messaging.ts
+++ b/src/api/chatsvc-messaging.ts
@@ -123,6 +123,14 @@ export interface SendMessageOptions {
    * combined with mentions or a thread reply.
    */
   scheduleAt?: string;
+  /**
+   * JSON-encoded `files` array string for file attachments.
+   *
+   * When provided, the message includes file attachment metadata in its
+   * `properties.files` field. Use `uploadFile()` or `uploadFiles()` from
+   * `sharepoint-api.ts` to upload files and generate this string.
+   */
+  files?: string;
 }
 
 /** Result of getting a 1:1 conversation. */
@@ -183,7 +191,7 @@ export async function sendMessage(
   }
   const { auth, region, baseUrl } = authResult.value;
 
-  const { replyToMessageId, contentType = 'markdown', subject, scheduleAt } = options;
+  const { replyToMessageId, contentType = 'markdown', subject, scheduleAt, files } = options;
   const displayName = getUserDisplayName() || 'User';
 
   const clientMessageId = generateClientMessageId();
@@ -244,6 +252,9 @@ export async function sendMessage(
   }
   if (subject && subject.trim()) {
     properties.subject = subject.trim();
+  }
+  if (files) {
+    properties.files = files;
   }
   if (Object.keys(properties).length > 0) {
     body.properties = properties;

--- a/src/api/sharepoint-api.ts
+++ b/src/api/sharepoint-api.ts
@@ -1,0 +1,331 @@
+/**
+ * SharePoint/OneDrive file upload API via Microsoft Graph.
+ *
+ * Teams file attachments work in two steps: (1) upload the file to the user's
+ * OneDrive "Microsoft Teams Chat Files" folder via the Graph API, then (2) send
+ * a chat message with a `files` property referencing the uploaded file.
+ *
+ * We use the Graph API (`graph.microsoft.com`) rather than the SharePoint REST
+ * API directly because:
+ * - The Graph token is already in the MSAL cache (broad delegated permissions)
+ * - No need to construct tenant-specific SharePoint URLs manually
+ * - The Graph response includes all SharePoint URLs needed for the `files` property
+ *
+ * Reverse-engineered from Teams web client network interception (2026-07-28).
+ */
+
+import { readFile } from 'node:fs/promises';
+import { basename, extname } from 'node:path';
+import { httpRequest } from '../utils/http.js';
+import { ErrorCode, createError } from '../types/errors.js';
+import { type Result, ok, err } from '../types/result.js';
+import { getValidGraphToken } from '../auth/token-extractor.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Subset of the Graph API DriveItem response that we need. */
+export interface DriveItem {
+  id: string;
+  name: string;
+  size?: number;
+  webUrl?: string;
+  sharepointIds?: {
+    siteId?: string;
+    siteUrl?: string;
+    webId?: string;
+    listId?: string;
+    listItemUniqueId?: string;
+  };
+  parentReference?: {
+    driveId?: string;
+    sharepointIds?: {
+      siteId?: string;
+      siteUrl?: string;
+      webId?: string;
+      listId?: string;
+      listItemUniqueId?: string;
+    };
+  };
+}
+
+/** Result of uploading a file. */
+export interface UploadFileResult {
+  /** The DriveItem ID from Graph/SharePoint. */
+  itemId: string;
+  /** The file name (may differ from input if renamed due to conflict). */
+  fileName: string;
+  /** File extension without the dot (e.g., "pdf"). */
+  fileType: string;
+  /** File size in bytes. */
+  fileSize?: number;
+  /** The SharePoint personal site base URL (e.g., "https://tenant-my.sharepoint.com/personal/user_domain_com/"). */
+  baseUrl: string;
+  /** The full SharePoint URL to the file. */
+  objectUrl: string;
+  /** The web URL from Graph (may differ slightly from objectUrl). */
+  webUrl?: string;
+  /** SharePoint list item unique ID (used in the `files` property). */
+  listItemUniqueId?: string;
+  /** The JSON-encoded `files` property string for the chatsvc message body. */
+  filesProperty: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Graph API base URL. */
+const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
+
+/** The OneDrive folder Teams uses for chat file attachments. */
+const TEAMS_CHAT_FILES_FOLDER = 'Microsoft Teams Chat Files';
+
+/** Maximum file size for simple upload (4 MB — Graph API limit for single PUT). */
+const MAX_SIMPLE_UPLOAD_SIZE = 4 * 1024 * 1024;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Gets the file extension without the leading dot (e.g., "pdf" from "doc.pdf").
+ */
+function getFileExtension(fileName: string): string {
+  const ext = extname(fileName).toLowerCase().replace(/^\./, '');
+  return ext || 'file';
+}
+
+/**
+ * Extracts the SharePoint personal site base URL from a DriveItem response.
+ *
+ * The base URL looks like: `https://{tenant}-my.sharepoint.com/personal/{user_folder}/`
+ */
+function extractBaseUrl(driveItem: DriveItem): string | null {
+  // Try sharepointIds.siteUrl first
+  const siteUrl = driveItem.sharepointIds?.siteUrl
+    ?? driveItem.parentReference?.sharepointIds?.siteUrl;
+  if (siteUrl) {
+    return siteUrl.endsWith('/') ? siteUrl : `${siteUrl}/`;
+  }
+
+  // Fallback: parse from webUrl
+  if (driveItem.webUrl) {
+    try {
+      const url = new URL(driveItem.webUrl);
+      // webUrl is like: https://{tenant}-my.sharepoint.com/personal/{user}/Documents/Microsoft Teams Chat Files/{file}
+      const pathParts = url.pathname.split('/');
+      // Find "personal" in the path and take the next segment
+      const personalIndex = pathParts.indexOf('personal');
+      if (personalIndex >= 0 && pathParts[personalIndex + 1]) {
+        const base = `${url.protocol}//${url.host}/personal/${pathParts[personalIndex + 1]}/`;
+        return base;
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Builds the `files` property JSON string from a Graph API DriveItem response.
+ *
+ * This is the exact format the Teams chatsvc API expects in the message body's
+ * `properties.files` field — a JSON-encoded string (not an array).
+ */
+export function buildFilesProperty(driveItem: DriveItem): string {
+  const baseUrl = extractBaseUrl(driveItem) ?? '';
+  const fileName = driveItem.name;
+  const fileType = getFileExtension(fileName);
+  const itemId = driveItem.id;
+  const listItemUniqueId = driveItem.sharepointIds?.listItemUniqueId
+    ?? driveItem.parentReference?.sharepointIds?.listItemUniqueId
+    ?? itemId;
+
+  const objectUrl = driveItem.webUrl
+    ?? `${baseUrl}Documents/${TEAMS_CHAT_FILES_FOLDER}/${encodeURIComponent(fileName)}`;
+
+  const file = {
+    itemid: itemId,
+    fileName,
+    fileType,
+    fileInfo: {
+      itemId: null,
+      fileUrl: objectUrl,
+      siteUrl: baseUrl,
+      serverRelativeUrl: '',
+      shareUrl: null,
+      shareId: null,
+    },
+    fileChicletState: {
+      serviceName: 'p2p',
+      state: 'active',
+    },
+    '@type': 'http://schema.skype.com/File',
+    version: 2,
+    id: itemId,
+    baseUrl,
+    objectUrl,
+    type: fileType,
+    title: fileName,
+    state: 'active',
+    chicletBreadcrumbs: null,
+    providerData: '',
+    botFileProperties: {},
+    isUploadError: null,
+    progressComplete: null,
+    permissionScope: 'anonymous',
+    filePreview: {
+      previewUrl: '',
+      previewHeight: 0,
+      previewWidth: 0,
+    },
+    sharepointIds: {
+      listId: driveItem.sharepointIds?.listId ?? null,
+      listItemUniqueId,
+      siteId: driveItem.sharepointIds?.siteId ?? null,
+      siteUrl: driveItem.sharepointIds?.siteUrl ?? null,
+      webId: driveItem.sharepointIds?.webId ?? null,
+    },
+    publication: null,
+    site: null,
+  };
+
+  return JSON.stringify([file]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// File Upload
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Uploads a local file to the user's OneDrive "Microsoft Teams Chat Files" folder.
+ *
+ * Uses the Graph API simple upload (PUT with content). For files larger than 4 MB,
+ * a session-based upload would be needed (not yet implemented).
+ *
+ * @param filePath - Absolute or relative path to the local file
+ * @returns Upload result with item metadata and the `files` property string
+ */
+export async function uploadFile(filePath: string): Promise<Result<UploadFileResult>> {
+  // Validate auth
+  const graphToken = getValidGraphToken();
+  if (!graphToken) {
+    return err(createError(
+      ErrorCode.AUTH_REQUIRED,
+      'ACTION REQUIRED: No valid Microsoft Graph token. You MUST call teams_login to authenticate before uploading files.',
+      { suggestions: ['Call teams_login to authenticate via browser'] }
+    ));
+  }
+
+  // Read the file
+  let fileBuffer: Buffer;
+  try {
+    fileBuffer = await readFile(filePath);
+  } catch (error) {
+    return err(createError(
+      ErrorCode.INVALID_INPUT,
+      `Failed to read file "${filePath}": ${error instanceof Error ? error.message : String(error)}`,
+      { retryable: false }
+    ));
+  }
+
+  // Check file size (Graph API simple upload limit is 4 MB)
+  if (fileBuffer.length > MAX_SIMPLE_UPLOAD_SIZE) {
+    return err(createError(
+      ErrorCode.INVALID_INPUT,
+      `File "${filePath}" is ${Math.round(fileBuffer.length / 1024 / 1024)} MB. Maximum size for upload is ${MAX_SIMPLE_UPLOAD_SIZE / 1024 / 1024} MB. Large file upload is not yet supported.`,
+      { retryable: false }
+    ));
+  }
+
+  const fileName = basename(filePath);
+
+  // Build the Graph API upload URL
+  // PUT /me/drive/root:/Microsoft Teams Chat Files/{filename}:/content
+  const uploadUrl = `${GRAPH_BASE_URL}/me/drive/root:/${encodeURIComponent(TEAMS_CHAT_FILES_FOLDER)}/${encodeURIComponent(fileName)}:/content`;
+
+  const response = await httpRequest<DriveItem>(uploadUrl, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `Bearer ${graphToken}`,
+      'Content-Type': 'application/octet-stream',
+    },
+    body: new Uint8Array(fileBuffer),
+    maxRetries: 1, // Don't retry uploads — could result in duplicate files
+  });
+
+  if (!response.ok) {
+    return response;
+  }
+
+  const driveItem = response.value.data;
+  const baseUrl = extractBaseUrl(driveItem);
+  if (!baseUrl) {
+    return err(createError(
+      ErrorCode.UNKNOWN,
+      `File uploaded successfully but could not determine SharePoint base URL from the response. Item ID: ${driveItem.id}`,
+      { retryable: false }
+    ));
+  }
+
+  const filesProperty = buildFilesProperty(driveItem);
+
+  return ok({
+    itemId: driveItem.id,
+    fileName: driveItem.name,
+    fileType: getFileExtension(driveItem.name),
+    fileSize: driveItem.size,
+    baseUrl,
+    objectUrl: driveItem.webUrl ?? `${baseUrl}Documents/${TEAMS_CHAT_FILES_FOLDER}/${encodeURIComponent(driveItem.name)}`,
+    webUrl: driveItem.webUrl,
+    listItemUniqueId: driveItem.sharepointIds?.listItemUniqueId
+      ?? driveItem.parentReference?.sharepointIds?.listItemUniqueId
+      ?? driveItem.id,
+    filesProperty,
+  });
+}
+
+/**
+ * Uploads multiple files and returns their combined `files` property string.
+ *
+ * The `files` property in the chatsvc message body is a JSON-encoded array.
+ * When multiple files are attached, their entries are merged into a single array.
+ *
+ * @param filePaths - Array of local file paths
+ * @returns Combined `files` property string and per-file upload results
+ */
+export async function uploadFiles(
+  filePaths: string[]
+): Promise<Result<{ filesProperty: string; uploads: UploadFileResult[] }>> {
+  const uploads: UploadFileResult[] = [];
+  const fileEntries: unknown[] = [];
+
+  for (const filePath of filePaths) {
+    const result = await uploadFile(filePath);
+    if (!result.ok) {
+      return result;
+    }
+    uploads.push(result.value);
+
+    // Parse the filesProperty (which is JSON.stringify([singleFile])) and merge
+    try {
+      const parsed = JSON.parse(result.value.filesProperty) as unknown[];
+      fileEntries.push(...parsed);
+    } catch {
+      return err(createError(
+        ErrorCode.UNKNOWN,
+        `Failed to parse files property for uploaded file "${result.value.fileName}"`,
+        { retryable: false }
+      ));
+    }
+  }
+
+  return ok({
+    filesProperty: JSON.stringify(fileEntries),
+    uploads,
+  });
+}

--- a/src/auth/token-extractor.ts
+++ b/src/auth/token-extractor.ts
@@ -322,6 +322,55 @@ export function extractSkypeSpacesToken(state?: SessionState): string | null {
   });
 }
 
+/**
+ * Extracts the Microsoft Graph API token from session state.
+ *
+ * This token is required for file upload operations (SharePoint/OneDrive).
+ * It has scope: https://graph.microsoft.com/Files.ReadWrite.All (or similar).
+ * The Teams web client's MSAL cache includes this token with broad delegated
+ * permissions including Files.ReadWrite.All.
+ */
+export function extractGraphToken(state?: SessionState): string | null {
+  return withLocalStorage(state, (localStorage) => {
+    let bestCandidate: { token: string; expiry: Date } | null = null;
+
+    for (const item of localStorage) {
+      try {
+        const entry = JSON.parse(item.value);
+        if (!entry.target || !isJwtToken(entry.secret)) continue;
+
+        // Look for graph.microsoft.com token
+        if (!entry.target.includes('graph.microsoft.com')) continue;
+
+        const payload = decodeJwtPayload(entry.secret);
+        if (!payload?.exp || typeof payload.exp !== 'number') continue;
+
+        const expiry = new Date(payload.exp * 1000);
+
+        // Skip expired tokens
+        if (expiry.getTime() <= Date.now()) continue;
+
+        // Keep the one with the latest expiry
+        if (!bestCandidate || expiry > bestCandidate.expiry) {
+          bestCandidate = { token: entry.secret, expiry };
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return bestCandidate?.token ?? null;
+  });
+}
+
+/**
+ * Gets a valid Graph token, extracting from session state if needed.
+ * Returns null if no valid token is available.
+ */
+export function getValidGraphToken(): string | null {
+  return extractGraphToken();
+}
+
 /** Region configuration from Teams discovery. */
 export interface RegionConfig {
   /** Base region (e.g., "amer", "emea", "apac") - used by chatsvc, csa APIs. */

--- a/src/auth/token-refresh-http.test.ts
+++ b/src/auth/token-refresh-http.test.ts
@@ -210,7 +210,7 @@ describe('refreshTokensViaHttp', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value.tokensRefreshed).toBe(3);
+      expect(result.value.tokensRefreshed).toBe(4);
       expect(result.value.skypeTokenRefreshed).toBe(true);
       expect(result.value.refreshTokenRotated).toBe(true);
     }
@@ -221,8 +221,8 @@ describe('refreshTokensViaHttp', () => {
     // Verify token cache was cleared
     expect(clearTokenCache).toHaveBeenCalledOnce();
 
-    // Verify fetch was called 4 times (3 token refreshes + 1 skype exchange)
-    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(4);
+    // Verify fetch was called 5 times (4 token refreshes + 1 skype exchange)
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(5);
   });
 
   it('updates skypetoken_asm cookies in session state', async () => {
@@ -313,8 +313,8 @@ describe('refreshTokensViaHttp', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      // 2 of 3 scopes succeeded (first one failed with network error)
-      expect(result.value.tokensRefreshed).toBe(2);
+      // 3 of 4 scopes succeeded (first one failed with network error)
+      expect(result.value.tokensRefreshed).toBe(3);
     }
   });
 
@@ -341,7 +341,7 @@ describe('refreshTokensViaHttp', () => {
     // Should still succeed — skype token failure is non-fatal
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value.tokensRefreshed).toBe(3);
+      expect(result.value.tokensRefreshed).toBe(4);
       expect(result.value.skypeTokenRefreshed).toBe(false);
     }
   });

--- a/src/auth/token-refresh-http.ts
+++ b/src/auth/token-refresh-http.ts
@@ -138,6 +138,11 @@ const REFRESH_SCOPES = [
     resource: 'chatsvcagg.teams.microsoft.com',
     scopes: 'https://chatsvcagg.teams.microsoft.com/.default offline_access',
   },
+  {
+    /** Microsoft Graph API for file uploads (SharePoint/OneDrive). */
+    resource: 'graph.microsoft.com',
+    scopes: 'https://graph.microsoft.com/.default offline_access',
+  },
 ] as const;
 
 /** HTTP request timeout for token refresh calls (ms). */

--- a/src/tools/file-tools.ts
+++ b/src/tools/file-tools.ts
@@ -7,6 +7,7 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { RegisteredTool, ToolContext, ToolResult } from './index.js';
 import { handleApiResult } from './index.js';
 import { getSharedFiles } from '../api/files-api.js';
+import { uploadFile } from '../api/sharepoint-api.js';
 import {
   DEFAULT_FILES_PAGE_SIZE,
   MAX_FILES_PAGE_SIZE,
@@ -20,6 +21,10 @@ export const GetSharedFilesInputSchema = z.object({
   conversationId: z.string().min(1),
   pageSize: z.number().min(1).max(MAX_FILES_PAGE_SIZE).optional().default(DEFAULT_FILES_PAGE_SIZE),
   skipToken: z.string().optional(),
+});
+
+export const UploadFileInputSchema = z.object({
+  filePath: z.string().min(1, 'File path cannot be empty'),
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -49,6 +54,21 @@ const getSharedFilesToolDefinition: Tool = {
   },
 };
 
+const uploadFileToolDefinition: Tool = {
+  name: 'teams_upload_file',
+  description: 'Upload a local file to the user\'s OneDrive "Microsoft Teams Chat Files" folder via the Microsoft Graph API. Returns the uploaded file\'s metadata including itemId, fileName, SharePoint URLs, and a filesProperty string. The filesProperty can be passed to teams_send_message as the attachments parameter to send the file as an attachment in a chat message. Maximum file size is 4 MB. The file path refers to the local filesystem of the machine running the MCP server.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      filePath: {
+        type: 'string',
+        description: 'Absolute or relative path to the local file to upload (e.g., "/path/to/document.pdf").',
+      },
+    },
+    required: ['filePath'],
+  },
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Handlers
 // ─────────────────────────────────────────────────────────────────────────────
@@ -70,6 +90,32 @@ async function handleGetSharedFiles(
   }));
 }
 
+async function handleUploadFile(
+  input: z.infer<typeof UploadFileInputSchema>,
+  _ctx: ToolContext
+): Promise<ToolResult> {
+  const result = await uploadFile(input.filePath);
+
+  if (!result.ok) {
+    return { success: false, error: result.error };
+  }
+
+  return {
+    success: true,
+    data: {
+      itemId: result.value.itemId,
+      fileName: result.value.fileName,
+      fileType: result.value.fileType,
+      fileSize: result.value.fileSize,
+      baseUrl: result.value.baseUrl,
+      objectUrl: result.value.objectUrl,
+      listItemUniqueId: result.value.listItemUniqueId,
+      filesProperty: result.value.filesProperty,
+      note: 'File uploaded to OneDrive. Pass the filesProperty to teams_send_message attachments to share it in a chat, or use teams_send_message with attachments parameter directly.',
+    },
+  };
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Exports
 // ─────────────────────────────────────────────────────────────────────────────
@@ -80,5 +126,11 @@ export const getSharedFilesTool: RegisteredTool<typeof GetSharedFilesInputSchema
   handler: handleGetSharedFiles,
 };
 
+export const uploadFileTool: RegisteredTool<typeof UploadFileInputSchema> = {
+  definition: uploadFileToolDefinition,
+  schema: UploadFileInputSchema,
+  handler: handleUploadFile,
+};
+
 /** All file-related tools. */
-export const fileTools = [getSharedFilesTool];
+export const fileTools = [getSharedFilesTool, uploadFileTool];

--- a/src/tools/message-tools.ts
+++ b/src/tools/message-tools.ts
@@ -26,6 +26,7 @@ import {
   waitForReply,
 } from '../api/chatsvc-api.js';
 import { getFavorites, addFavorite, removeFavorite, getCustomEmojis } from '../api/csa-api.js';
+import { uploadFiles } from '../api/sharepoint-api.js';
 import { parseTeamsMessageUrl } from '../utils/parsers.js';
 import { ErrorCode, createError } from '../types/errors.js';
 import { SELF_CHAT_ID, MAX_THREAD_LIMIT, DEFAULT_THREAD_LIMIT, MAX_WAIT_SECONDS, STANDARD_EMOJIS } from '../constants.js';
@@ -41,6 +42,9 @@ export const SendMessageInputSchema = z.object({
   contentType: z.enum(['auto', 'text', 'html', 'markdown']).optional(),
   subject: z.string().optional(),
   scheduleAt: z.string().optional(),
+  attachments: z.array(z.object({
+    filePath: z.string().min(1, 'File path cannot be empty'),
+  })).optional().describe('Local file paths to upload and attach to the message'),
 });
 
 export const FavoriteInputSchema = z.object({
@@ -138,7 +142,7 @@ export const WaitForReplyInputSchema = z.object({
 
 const sendMessageToolDefinition: Tool = {
   name: 'teams_send_message',
-  description: 'Send a message to a Teams conversation. Use markdown for formatting (not HTML): **bold**, *italic*, ~~strikethrough~~, `code`, ```code blocks```, lists, and newlines. Supports @mentions: people with @[Name](mri) (MRI from teams_search_people) and channel tags with @[TagName](tag:tagId) (IDs from teams_get_tags). Markdown links [text](url) support http(s) and mailto. Defaults to self-notes (48:notes). For channel thread replies, provide replyToMessageId. For a new channel thread with a title, provide subject. To schedule for later, provide scheduleAt (ISO 8601). Set contentType to "text" to send content verbatim without markdown interpretation.',
+  description: 'Send a message to a Teams conversation. Use markdown for formatting (not HTML): **bold**, *italic*, ~~strikethrough~~, `code`, ```code blocks```, lists, and newlines. Supports @mentions: people with @[Name](mri) (MRI from teams_search_people) and channel tags with @[TagName](tag:tagId) (IDs from teams_get_tags). Markdown links [text](url) support http(s) and mailto. Defaults to self-notes (48:notes). For channel thread replies, provide replyToMessageId. For a new channel thread with a title, provide subject. To schedule for later, provide scheduleAt (ISO 8601). Set contentType to "text" to send content verbatim without markdown interpretation. To attach files, provide attachments with local file paths — files are uploaded to OneDrive and referenced in the message. Cannot combine attachments with scheduleAt.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -166,6 +170,20 @@ const sendMessageToolDefinition: Tool = {
       scheduleAt: {
         type: 'string',
         description: 'Schedule the message for future delivery. ISO 8601 (e.g. "2026-04-11T09:00:00Z"); a timezone-less value is treated as UTC. Cannot be combined with @mentions or replyToMessageId.',
+      },
+      attachments: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            filePath: {
+              type: 'string',
+              description: 'Absolute or relative path to the local file to upload and attach (e.g., "/path/to/document.pdf"). Max 4 MB per file.',
+            },
+          },
+          required: ['filePath'],
+        },
+        description: 'Files to upload and attach to the message. Each file is uploaded to the user\'s OneDrive "Microsoft Teams Chat Files" folder and referenced in the message. Cannot be combined with scheduleAt. Max 4 MB per file. To upload a file without sending a message, use teams_upload_file.',
       },
     },
     required: ['content'],
@@ -555,11 +573,34 @@ async function handleSendMessage(
   input: z.infer<typeof SendMessageInputSchema>,
   _ctx: ToolContext
 ): Promise<ToolResult> {
+  // Upload attachments (if any) before sending the message
+  let filesProperty: string | undefined;
+  if (input.attachments && input.attachments.length > 0) {
+    if (input.scheduleAt) {
+      return {
+        success: false,
+        error: createError(
+          ErrorCode.INVALID_INPUT,
+          'Attachments cannot be combined with scheduleAt (scheduled messages). Remove scheduleAt or attachments.',
+          { retryable: false }
+        ),
+      };
+    }
+
+    const filePaths = input.attachments.map(a => a.filePath);
+    const uploadResult = await uploadFiles(filePaths);
+    if (!uploadResult.ok) {
+      return { success: false, error: uploadResult.error };
+    }
+    filesProperty = uploadResult.value.filesProperty;
+  }
+
   const result = await sendMessage(input.conversationId, input.content, {
     replyToMessageId: input.replyToMessageId,
     contentType: input.contentType,
     subject: input.subject,
     scheduleAt: input.scheduleAt,
+    files: filesProperty,
   });
 
   if (!result.ok) {
@@ -599,6 +640,12 @@ async function handleSendMessage(
     response.note = 'Message posted as a reply to the thread. Use serverMessageId (not messageId) for reactions, edits, or threading.';
   } else if (serverMessageId) {
     response.note = 'Use serverMessageId (not messageId) for reactions, edits, or threading.';
+  }
+
+  // Include attachment info if files were uploaded
+  if (input.attachments && input.attachments.length > 0) {
+    response.attachments = input.attachments.map(a => ({ filePath: a.filePath }));
+    response.note = `Message sent with ${input.attachments.length} file attachment(s). Files are uploaded to OneDrive "Microsoft Teams Chat Files" folder.`;
   }
 
   return { success: true, data: response };


### PR DESCRIPTION
## Summary

Adds the ability to upload local files and send them as attachments in Teams chat messages. Files are uploaded to the user's OneDrive "Microsoft Teams Chat Files" folder via the Microsoft Graph API, then referenced in the chatsvc message body's `properties.files` field — the exact same flow the Teams web client uses.

## Changes

### New Tool: `teams_upload_file`
Uploads a local file to OneDrive and returns metadata (itemId, SharePoint URLs, and a `filesProperty` string for use with `teams_send_message`).

### Extended: `teams_send_message`
New optional `attachments` parameter — an array of `{ filePath }` objects. When provided, files are uploaded before the message is sent and referenced as attachments.

### Implementation Details

| File | Change |
|------|--------|
| `src/auth/token-extractor.ts` | Add `extractGraphToken()` / `getValidGraphToken()` — extracts the Graph API token from the MSAL cache (already present from Teams web client login with `Files.ReadWrite.All` scope) |
| `src/auth/token-refresh-http.ts` | Add `graph.microsoft.com` to `REFRESH_SCOPES` so the Graph token is refreshed alongside existing tokens |
| `src/api/sharepoint-api.ts` | **New module** — `uploadFile()`, `uploadFiles()`, and `buildFilesProperty()`. Uses Graph API `PUT /me/drive/root:/Microsoft Teams Chat Files/{filename}:/content` and builds the exact `files` JSON format Teams expects |
| `src/api/chatsvc-messaging.ts` | Add `files?: string` to `SendMessageOptions` and include it in the message body `properties` |
| `src/tools/file-tools.ts` | Register `teams_upload_file` tool |
| `src/tools/message-tools.ts` | Add `attachments` parameter to `teams_send_message` schema, handler, and tool definition |

### How It Works

1. **Upload**: File bytes are PUT to Graph API → OneDrive "Microsoft Teams Chat Files" folder
2. **Build files property**: The Graph response (DriveItem with `sharepointIds`, `webUrl`, etc.) is mapped to the exact JSON format Teams expects in `properties.files`
3. **Send message**: The message is sent via the existing chatsvc API with the `files` property included

## Limitations

- **Max 4 MB per file** (Graph API simple upload limit). Session-based upload for larger files is not yet implemented.
- The Graph token must be present in the MSAL cache (it is after a normal Teams web client login).

## Testing

- ✅ `npm run build` — compiles cleanly
- ✅ `npm run typecheck` — no type errors
- ✅ `npm run lint` — no lint errors
- ✅ `npm test` — all 389 tests pass (updated token-refresh-http tests for the new 4th Graph scope)

## Plan

Based on the reverse-engineering plan captured from Teams web client network interception. The implementation uses the Graph API (rather than the SharePoint REST API directly) for simplicity — the Graph token is already in the MSAL cache and the Graph response includes all SharePoint URLs needed for the `files` property.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>